### PR TITLE
Feature/us18980 force reset pwd

### DIFF
--- a/Gateway/crds-angular.test/Services/LoginServiceTest.cs
+++ b/Gateway/crds-angular.test/Services/LoginServiceTest.cs
@@ -23,6 +23,7 @@ namespace crds_angular.test.Services
         private Mock<MPInterfaces.IContactRepository> _contactService;
         private Mock<IEmailCommunication> _emailCommunication;
         private Mock<MPInterfaces.IUserRepository> _userRepository;
+        private Mock<MPInterfaces.IContactRepository> _contactRepository;
         
 
         [SetUp]
@@ -34,8 +35,9 @@ namespace crds_angular.test.Services
             _contactService = new Mock<MPInterfaces.IContactRepository>();
             _emailCommunication = new Mock<IEmailCommunication>();
             _userRepository = new Mock<MPInterfaces.IUserRepository>();
+            _contactRepository = new Mock<MPInterfaces.IContactRepository>();
             
-            _loginService = new LoginService(_authenticationRepository.Object, _configurationWrapper.Object, _contactService.Object, _emailCommunication.Object, _userRepository.Object);
+            _loginService = new LoginService(_authenticationRepository.Object, _configurationWrapper.Object, _contactService.Object, _emailCommunication.Object, _userRepository.Object, _contact);
         }
 
         [Test]

--- a/Gateway/crds-angular/Services/LoginService.cs
+++ b/Gateway/crds-angular/Services/LoginService.cs
@@ -30,6 +30,7 @@ namespace crds_angular.Services
         private readonly IAuthenticationRepository _authenticationRepository;
         private readonly string _identityServiceUrl;
         private readonly IContactRepository _contactRepository;
+        private readonly string _identityServiceSharedSecret;
         protected virtual HttpClient client { get { return _client; } }
         private static readonly HttpClient _client = new HttpClient();
 
@@ -41,6 +42,7 @@ namespace crds_angular.Services
             _userRepository = userRepository;
             _authenticationRepository = authenticationRepository;
             _identityServiceUrl = _configurationWrapper.GetEnvironmentVarAsString("IDENTITY_SERVICE_URL");
+            _identityServiceSharedSecret = _configurationWrapper.GetEnvironmentVarAsString("IDENTITY_SHARED_SECRET");
             _contactRepository = contactRepository;
         }
 
@@ -225,11 +227,15 @@ namespace crds_angular.Services
             });
         }
 
-        private Boolean NotifyIdentityofPasswordUpdate(string emailAddress, string userAccessToken)
+        private Boolean NotifyIdentityofPasswordUpdate(string emailAddress)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, _identityServiceUrl + $"/api/identities/{emailAddress}/passwordupdated");
+            var request = new HttpRequestMessage(HttpMethod.Post, _identityServiceUrl + $"/api/identities/{emailAddress}/passwordreset");
             request.Headers.Add("Accept", "application/json");
-            request.Headers.Add("Authorization", userAccessToken);
+            var body = new
+            {
+                code = _identityServiceSharedSecret
+            };
+            request.Content = new StringContent(JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
             try
             {
                 var response = client.SendAsync(request).Result;

--- a/Gateway/crds-angular/Services/LoginService.cs
+++ b/Gateway/crds-angular/Services/LoginService.cs
@@ -244,31 +244,5 @@ namespace crds_angular.Services
             }
             
         }
-
-        private Boolean ForceOktaPasswordReset(string emailAddress, string newPassword, string accessToken)
-        {
-            var request = new HttpRequestMessage(HttpMethod.Get, _identityServiceUrl + $"/api/identities/{emailAddress}/password");
-            request.Headers.Add("Accept", "application/json");
-            request.Headers.Add("Authorization", accessToken);
-            var body = new
-            {
-                NewPassword = newPassword
-            };
-            var json = JsonConvert.SerializeObject(body);
-            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            try
-            {
-                var response = client.SendAsync(request).Result;
-                if (response.IsSuccessStatusCode)
-                    return true;
-                return false;
-            }
-            catch
-            {
-                _logger.Info($"Could not update password for user {emailAddress} in Okta.");
-                return false;
-            }
-        }
-
     }
 }


### PR DESCRIPTION
Gateway to now call the Serverless function upon a Reset Password flow being completed in MP.  This will update the Okta user so that passwords always match.

Gateway to now call the serverless function upon a Profile update, if that update includes a change to the users password.  This update will call the serverless function to update Okta so that the passwords always match.

Retooling Notification to Identity service on password reset to new endpoint (/passwordreset) to allow for lack of auth token.  New endpoint in Identity service will still notify Differential the same way as /passwordchanged.

Int and Demo have new shared secret in env variables.  Endpoint in Identity not yet created.