### PR TITLE
HotFix Removed comma from email search

### DIFF
--- a/Gateway/MinistryPlatform.Translation/Repositories/UserRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/UserRepository.cs
@@ -184,7 +184,7 @@ namespace MinistryPlatform.Translation.Repositories
 
         public int GetUserIdByUsername(string email)
         {
-            var records = _ministryPlatformService.GetRecordsDict(Convert.ToInt32(ConfigurationManager.AppSettings["Users"]), ApiLogin(), ("," + email));
+            var records = _ministryPlatformService.GetRecordsDict(Convert.ToInt32(ConfigurationManager.AppSettings["Users"]), ApiLogin(), (email));
             if (records.Count != 1)
             {
                 throw new ApplicationException("User email did not return exactly one user record");


### PR DESCRIPTION
This is a hotfix, there is a comma hard coded into the parameters for _ministryPlatformService.GetRecordsDict line 187 of the UserRepository. This comma is being appended to the beginning of the email address, and when it is being searched for in the Users table in MP 0 results are returned because of the comma at the beginning of the string. I have merged into Development and all unit test passed, as well as running the code locally the password reset created a draft in MP. 