### PR TITLE
feature/US20246 - API tests for request password reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,4 +216,7 @@ Gateway/Crossroads.AsyncJobs/Unity.config
 /CI/SQL/20171023_150300_US10195-calculate-srfp-sp.sql
 /Gateway/*.DotSettings
 
+# Ignore Cypress generated files
+**/cypress/screenshots
+**/cypress/videos
 loadenv.ps1

--- a/Gateway/crds-angular.api_test/cypress/config/vault_config.json
+++ b/Gateway/crds-angular.api_test/cypress/config/vault_config.json
@@ -1,8 +1,8 @@
 {
   "sources": [
     {
-      "secret": "Crossroads.Automation",
-      "keys": ["BEN_KENOBI_PW"]
+      "secret": "crds-angular.api_test",
+      "keys": ["BEN_KENOBI_PW", "TEST_GATEKEEPER_PW", "TEST_GATEKEEPERJR_PW"]
     }
   ]
 }

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_login_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_login_prodspec.ts
@@ -1,28 +1,26 @@
-import { TestConfig, TestCase, unzipTests } from "../../shared/test_scenario_factory";
+import { TestConfig, TestCase, unzipTests } from "cypress/shared/test_scenario_factory";
+import { Ben } from "cypress/shared/users";
 import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
 import { mpLoginBasicAuthContract, mpLoginSchemaProperties } from "./schemas/loginResponse";
 
 // Data Setup
-const username = "mpcrds+auto+2@gmail.com";
-const password = Cypress.env("BEN_KENOBI_PW");
-
 const testConfig: TestConfig[] = [
   {
-    setup: { description: "Valid User", body: { username, password } },
+    setup: { description: "Valid User", body: { username: Ben.email, password: Ben.password } },
     result: {
       status: 200,
       body: {
         schemas: [mpLoginSchemaProperties, mpLoginBasicAuthContract],
-        properties: [{ name: "userEmail", value: username }]
+        properties: [{ name: "userEmail", value: Ben.email }]
       }
     }
   },
   {
     setup: [
-      { description: "Incorrect Password", body: { username, password: "bad" } },
-      { description: "Missing Password", body: { username } },
-      { description: "Missing Username", body: { password } },
-      { description: "User Doesn't Exist", body: { username: "fakeUser@fakemail.wxyz", password } },
+      { description: "Incorrect Password", body: { username: Ben.email, password: "bad" } },
+      { description: "Missing Password", body: { username: Ben.email } },
+      { description: "Missing Username", body: { password: Ben.password } },
+      { description: "User Doesn't Exist", body: { username: "fakeUser@fakemail.wxyz", password: Ben.password } },
       { description: "Body Undefined", body: undefined },
       { description: "Body Null", body: null },
       { description: "Body Empty String", body: "" }

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_login_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_login_prodspec.ts
@@ -1,68 +1,62 @@
-import { scenarioFactory, TestScenario, TestScenarioRequest, TestScenarioResponse } from "../../shared/test_scenario_factory";
+import { TestConfig, TestCase, unzipTests } from "../../shared/test_scenario_factory";
 import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
 import { mpLoginBasicAuthContract, mpLoginSchemaProperties } from "./schemas/loginResponse";
-chai.use(require('chai-json-schema-ajv')
-  .create({
-    verbose: true
-  }));
 
 // Data Setup
 const username = "mpcrds+auto+2@gmail.com";
 const password = Cypress.env("BEN_KENOBI_PW");
 
-const validRequest: TestScenarioRequest[] = [
-  { description: "Valid User", body: { username, password } }
+const testConfig: TestConfig[] = [
+  {
+    setup: { description: "Valid User", body: { username, password } },
+    result: {
+      status: 200,
+      body: {
+        schemas: [mpLoginSchemaProperties, mpLoginBasicAuthContract],
+        properties: [{ name: "userEmail", value: username }]
+      }
+    }
+  },
+  {
+    setup: [
+      { description: "Incorrect Password", body: { username, password: "bad" } },
+      { description: "Missing Password", body: { username } },
+      { description: "Missing Username", body: { password } },
+      { description: "User Doesn't Exist", body: { username: "fakeUser@fakemail.wxyz", password } },
+      { description: "Body Undefined", body: undefined },
+      { description: "Body Null", body: null },
+      { description: "Body Empty String", body: "" }
+    ],
+    result: {
+      status: 400,
+      body: {
+        schemas: [badRequestProperties, badRequestContract],
+        properties: [{ name: "message", value: "Login Failed" }]
+      }
+    }
+  }
 ];
-
-const validResponse: TestScenarioResponse = {
-  status: 200,
-  schemas: [mpLoginSchemaProperties, mpLoginBasicAuthContract],
-  properties: [{ name: "userEmail", value: username }]
-};
-
-const badRequest: TestScenarioRequest[] = [
-  { description: "Incorrect Password", body: { username, password: "bad" } },
-  { description: "Missing Password", body: { username } },
-  { description: "Missing Username", body: { password } },
-  { description: "User Doesn't Exist", body: { username: "fakeUser@fakemail.wxyz", password } },
-  { description: "Body Undefined", body: undefined },
-  { description: "Body Null", body: null },
-  { description: "Body Empty String", body: "" }
-];
-
-const badResponse: TestScenarioResponse = {
-  status: 400,
-  schemas: [badRequestProperties, badRequestContract],
-  properties: [{ name: "message", value: "Login Failed" }]
-};
 
 // Run Tests
 describe('POST /api/login', () => {
-  const okScenarios = scenarioFactory(validRequest, validResponse);
-  const badRequestScenarios = scenarioFactory(badRequest, badResponse);
-  const allScenarios = okScenarios.concat(badRequestScenarios);
+  unzipTests(testConfig)
+    .forEach((t: TestCase) => {
+      it(t.title, () => {
+        //Arrange
+        const mpLoginRequest = {
+          url: "/api/login",
+          method: "POST",
+          body: t.setup.body,
+          headers: t.setup.header,
+          failOnStatusCode: false
+        };
 
-  allScenarios.forEach((t: TestScenario) => {
-    it(t.title, () => {
-      //Arrange
-      const mpLoginRequest = {
-        url: "/api/login",
-        method: "POST",
-        body: t.request.body,
-        failOnStatusCode: false
-      };
-
-      //Act
-      cy.request(mpLoginRequest).as('response');
-
-      //Assert
-      //Verify response status
-      cy.get('@response').its('status').should('eq', t.response.status);
-
-      //Verify response body
-      cy.get('@response').its('body').toJSON().as('body');
-      t.response.schemas?.forEach((schema) => cy.get('@body').should('have.jsonSchema', schema));
-      t.response.properties?.forEach((prop) => cy.get('@body').should('have.property', prop.name, prop.value));
+        //Act & Assert
+        cy.request(mpLoginRequest)
+          .verifyStatus(t.result.status)
+          .itsBody(t.result.body)
+          .verifySchema(t.result.body)
+          .verifyProperties(t.result.body);
+      });
     });
-  });
 });

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_requestpasswordreset_mobile_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_requestpasswordreset_mobile_spec.ts
@@ -1,5 +1,5 @@
 import { TestCase, TestConfig, unzipTests } from "cypress/shared/test_scenario_factory";
-import { Ben, KeeperJr, Load } from "cypress/shared/users";
+import { Ben } from "cypress/shared/users";
 import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
 
 // Data Setup
@@ -11,7 +11,7 @@ const testConfig: TestConfig[] = [
   {
     setup: [
       { description: "Person Doesn't Exist", body: { email: "this_email_should_not_exist@fake_emails.io" } },
-      { description: "Person has Contact Record but no User Record", body: { email: Load.email } },
+      { description: "Person has Contact Record but no User Record", body: { email: "mpcrds+LoadTest_98@gmail.com" } },
       { description: "Invalid Email", body: { email: "{" } },
     ],
     result: { status: 200 }, //Not technically a bug but misleading to user
@@ -25,7 +25,7 @@ const testConfig: TestConfig[] = [
   },
   {
     setup: [
-      { description: "Email is Subset of Another Email (bug)", body: { email: KeeperJr.email } }
+      { description: "Email is Subset of Another Email (bug)", body: { email: "lia@differential.com" } }
     ],
     result: { status: 200 },
     preferredResult: { status: 200 } //Should still have valid output, but won't error on server side
@@ -60,12 +60,12 @@ const testConfig: TestConfig[] = [
 ];
 
 // Run Tests
-describe('POST /api/requestpasswordreset', () => {
+describe('POST /api/requestpasswordreset/mobile', () => {
   unzipTests(testConfig)
     .forEach((t: TestCase) => {
       it(t.title, () => {
         const mpRequestPasswordReset: Partial<Cypress.RequestOptions> = {
-          url: "/api/requestpasswordreset",
+          url: "/api/requestpasswordreset/mobile",
           method: "POST",
           body: t.setup.body,
           headers: t.setup.header,

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_requestpasswordreset_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_requestpasswordreset_spec.ts
@@ -1,0 +1,86 @@
+import { TestConfig, TestCase, unzipTests, } from "../../shared/test_scenario_factory";
+import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
+
+// Data Setup
+const email = "mpcrds+auto+2@gmail.com";
+
+const testConfig: TestConfig[] = [
+  {
+    setup: { description: "Valid Request", body: { email } },
+    result: { status: 200 }
+  },
+  {
+    setup: [
+      { description: "Person Doesn't Exist", body: { email: "this_email_should_not_exist@fake_emails.io" } },
+      { description: "Person has Contact Record but no User Record", body: { email: "mpcrds+LoadTest_98@gmail.com" } },
+      { description: "Invalid Email", body: { email: "{" } },
+    ],
+    result: { status: 200 }, //Not technically a bug but misleading to user
+    preferredResult: {
+      status: 404,
+      body: {
+        schemas: [badRequestProperties, badRequestContract],
+        properties: [{ name: "message", value: "User Not Found" }]
+      }
+    }
+  },
+  {
+    setup: [
+      { description: "Email is Subset of Another Email (bug)", body: { email: "lia@differential.com" } }
+    ],
+    result: { status: 200 },
+    preferredResult: { status: 200 } //Should still have valid output, but won't error on server side
+  },
+  {
+    setup: { description: "Email is Undefined", body: {} },
+    result: { status: 200 }, //Not technically a bug but misleading to user
+    preferredResult: {
+      status: 400,
+      body: {
+        schemas: [badRequestProperties, badRequestContract],
+        properties: [{ name: "message", value: "Missing Email" }]
+      }
+    }
+  },
+  {
+    setup: { description: "Missing Body" },
+    result: {
+      status: 500,
+      body: {
+        schemas: [{ type: "string", maxLength: 0 }]
+      }
+    }, //Not technically a bug but error could be more descriptive
+    preferredResult: {
+      status: 400,
+      body: {
+        schemas: [badRequestProperties, badRequestContract],
+        properties: [{ name: "message", value: "Missing Email" }]
+      }
+    }
+  }
+];
+
+// Run Tests
+describe('POST /api/requestpasswordreset', () => {
+  unzipTests(testConfig)
+    .forEach((t: TestCase) => {
+      it(t.title, () => {
+        const mpRequestPasswordReset: Partial<Cypress.RequestOptions> = {
+          url: "/api/requestpasswordreset",
+          method: "POST",
+          body: t.setup.body,
+          headers: t.setup.header,
+          failOnStatusCode: false
+        };
+
+        //Act & Assert
+        cy.request(mpRequestPasswordReset)
+          .verifyStatus(t.result.status)
+          .itsBody(t.result.body)
+          .verifySchema(t.result.body?.schemas)
+          .verifyProperties(t.result.body?.properties);
+      });
+    });
+});
+
+

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_versioned_request-password-reset-mobile_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_versioned_request-password-reset-mobile_prodspec.ts
@@ -1,0 +1,57 @@
+import { TestCase, TestConfig, unzipTests } from "cypress/shared/test_scenario_factory";
+import { Ben } from "cypress/shared/users";
+import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
+/**
+ * This endpoint is an alternate name for the POST /api/requestpasswordreset/mobile endpoint.
+ * Tests here are lighter tests runnable in Prod - More robust tests are run in the
+ * POST /api/requestpasswordreset/mobile test file.
+*/
+
+// Data Setup
+const testConfig: TestConfig[] = [
+  {
+    setup: { description: "Valid Request", body: { email: Ben.email } },
+    result: { status: 200 }
+  },
+  {
+    setup: { description: "Missing Body" },
+    result: {
+      status: 500,
+      body: {
+        schemas: [{ type: "string", maxLength: 0 }]
+      }
+    }, //Not technically a bug but error could be more descriptive
+    preferredResult: {
+      status: 400,
+      body: {
+        schemas: [badRequestProperties, badRequestContract],
+        properties: [{ name: "message", value: "Missing Email" }]
+      }
+    }
+  }
+];
+
+// Run Tests
+describe('POST /api/v1.0.0/request-password-reset-mobile', () => {
+  unzipTests(testConfig)
+    .forEach((t: TestCase) => {
+      it(t.title, () => {
+        const mpRequestPasswordReset: Partial<Cypress.RequestOptions> = {
+          url: "/api/v1.0.0/request-password-reset-mobile",
+          method: "POST",
+          body: t.setup.body,
+          headers: t.setup.header,
+          failOnStatusCode: false
+        };
+
+        //Act & Assert
+        cy.request(mpRequestPasswordReset)
+          .verifyStatus(t.result.status)
+          .itsBody(t.result.body)
+          .verifySchema(t.result.body?.schemas)
+          .verifyProperties(t.result.body?.properties);
+      });
+    });
+});
+
+

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_versioned_request-password-reset_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_versioned_request-password-reset_prodspec.ts
@@ -1,0 +1,57 @@
+import { TestCase, TestConfig, unzipTests } from "cypress/shared/test_scenario_factory";
+import { Ben } from "cypress/shared/users";
+import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
+/**
+ * This endpoint is an alternate name for the POST /api/requestpasswordreset endpoint.
+ * Tests here are lighter tests runnable in Prod - More robust tests are run in the
+ * POST /api/requestpasswordreset test file.
+*/
+
+// Data Setup
+const testConfig: TestConfig[] = [
+  {
+    setup: { description: "Valid Request", body: { email: Ben.email } },
+    result: { status: 200 }
+  },
+  {
+    setup: { description: "Missing Body" },
+    result: {
+      status: 500,
+      body: {
+        schemas: [{ type: "string", maxLength: 0 }]
+      }
+    }, //Not technically a bug but error could be more descriptive
+    preferredResult: {
+      status: 400,
+      body: {
+        schemas: [badRequestProperties, badRequestContract],
+        properties: [{ name: "message", value: "Missing Email" }]
+      }
+    }
+  }
+];
+
+// Run Tests
+describe('POST /api/v1.0.0/request-password-reset', () => {
+  unzipTests(testConfig)
+    .forEach((t: TestCase) => {
+      it(t.title, () => {
+        const mpRequestPasswordReset: Partial<Cypress.RequestOptions> = {
+          url: "/api/v1.0.0/request-password-reset",
+          method: "POST",
+          body: t.setup.body,
+          headers: t.setup.header,
+          failOnStatusCode: false
+        };
+
+        //Act & Assert
+        cy.request(mpRequestPasswordReset)
+          .verifyStatus(t.result.status)
+          .itsBody(t.result.body)
+          .verifySchema(t.result.body?.schemas)
+          .verifyProperties(t.result.body?.properties);
+      });
+    });
+});
+
+

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/schemas/unsupportedMediaResponse.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/schemas/unsupportedMediaResponse.ts
@@ -1,0 +1,15 @@
+export const unsupportedMediaProperties = {
+  title: "Unsupported Media response - property types",
+  type: "object",
+  properties: {
+    Message:{
+      type: "string"
+    }
+  }
+};
+
+export const unsupportedMediaContract = {
+  title: "Unsupported Media response - testability contract",
+  type: "object",
+  required: ["Message"]
+};

--- a/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.ts
@@ -1,30 +1,70 @@
-export interface TestScenarioRequest {
+/**
+ * Schema to define test scenarios and their response concisely
+ * Use the unzipTests function with a TestConfig or TestConfig[] to generate a TestCase[]
+ */
+export interface TestConfig {
+  setup: TestSetup | TestSetup[];
+  result: TestResult;
+  /**
+   * Preferred Output values are not tested, but capture the expected output for a defect scenario, or a suggestion for improvement
+   */
+  preferredResult?: TestResult;
+}
+
+export interface TestCase {
+  title: string;
+  setup: TestSetup;
+  result: TestResult;
+}
+
+export interface TestSetup {
   description: string;
   body?: any;
+  header?: any;
 }
 
-export interface TestScenarioResponse {
+export interface TestResult {
   status: number;
+  body?: ResultBody;
+}
+
+export interface ResultBody {
   schemas?: object[];
-  properties?: { name: string, value: string }[];
+  properties?: PropertyCompare[];
 }
 
-export interface TestScenario {
-  title: string;
-  request: TestScenarioRequest;
-  response: TestScenarioResponse;
-}
+export interface PropertyCompare {
+  name: string;
+  value: string;
+  /**
+   * If false, compares with 'includes'; defaults to exact match
+   */
+  exactMatch?: boolean;
+ }
 
-/**
- * Builds a list of TestScenarios given a list of requests and their common response
- * @param requestList
- * @param response
- */
-export function scenarioFactory(requestList: TestScenarioRequest[], response: TestScenarioResponse): TestScenario[] {
-  const testTitle = (request: TestScenarioRequest, response: TestScenarioResponse) => {
-    return `Given ${request.description}; Expect status ${response.status}${response.schemas ? ", valid schema":""}${response.properties ? ", correct property values":""}`;
+function unzip(config: TestConfig): TestCase[]{
+  const testTitle = (setup: TestSetup, result: TestResult) => {
+    return `Given ${setup.description}; Expect status ${result.status}${result.body?.schemas ? ", valid schema":""}${result.body?.properties ? ", correct property values":""}`;
   };
 
-  let scenarios: TestScenario[] = requestList?.map((request) => ({ title: testTitle(request,response), request, response }));
+  let scenarios: TestCase[];
+  if(Array.isArray(config.setup)){
+    //handle individual
+    scenarios = config.setup.map((setup) => ({ title: testTitle(setup, config.result), setup, result: config.result }));
+  }
+  else {
+    scenarios = [{ title: testTitle(config.setup, config.result), setup: config.setup, result: config.result }];
+  }
+
   return scenarios;
+}
+
+export function unzipTests(zippedTests: TestConfig | TestConfig[]): TestCase[] {
+  if(Array.isArray(zippedTests)){
+    return zippedTests.map((config) => (unzip(config)))
+    .reduce((accumulator, value) => accumulator.concat(value), []); //TODO use .flat
+  }
+  else {
+    return unzip(zippedTests);
+  }
 }

--- a/Gateway/crds-angular.api_test/cypress/shared/users.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/users.ts
@@ -1,0 +1,46 @@
+export interface TestUser {
+  email: string;
+  password?: string;
+}
+
+/**
+ * Ben is a test user with the same MP contact ID in every environment.
+ * It is safe to authenticate with either MP or Okta, and will be safe post-cutover.
+ * DO NOT change his email, password or anything that may prevent him from logging in,
+ *   even temporarily. His account is used by many automated tests.
+ */
+export const Ben: TestUser = {
+  email: "mpcrds+auto+2@gmail.com",
+  password: Cypress.env("BEN_KENOBI_PW")
+};
+
+
+/**
+ * Gate is a test user in non-prod environments.
+ * They cannot be authenticated through Okta in Demo.
+ */
+export const Gatekeeper: TestUser = {
+  email: "mpcrds+auto+gatekeeper@testmail.com",
+  password: Cypress.env("TEST_GATEKEEPER_PW")
+};
+
+
+/**
+ * Jr is a test user in non-prod environments.
+ * They cannot be authenticated through Okta in Demo.
+ * They have an email address that is a subset of another user's email address.
+ */
+export const KeeperJr: TestUser = {
+  email: "auto+gatekeeper@testmail.com",
+  password: Cypress.env("TEST_GATEKEEPERJR_PW")
+};
+
+
+/**
+ * Load has a MP Contact record only in all environments.
+ * They cannot be authenticated.
+ */
+export const Load: TestUser = {
+  email: "mpcrds+LoadTest_98@gmail.com",
+  password: null
+};

--- a/Gateway/crds-angular.api_test/cypress/support/commands.ts
+++ b/Gateway/crds-angular.api_test/cypress/support/commands.ts
@@ -23,8 +23,3 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-
-//TODO add Typescript definition for this
-Cypress.Commands.add("toJSON", { prevSubject: true}, (subject) => {
-  return typeof subject === 'string' ? JSON.parse(subject) : subject;
-});

--- a/Gateway/crds-angular.api_test/cypress/support/index.ts
+++ b/Gateway/crds-angular.api_test/cypress/support/index.ts
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+import './responseCommands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/Gateway/crds-angular.api_test/cypress/support/responseCommands.ts
+++ b/Gateway/crds-angular.api_test/cypress/support/responseCommands.ts
@@ -1,0 +1,50 @@
+import { ResultBody } from "cypress/shared/test_scenario_factory";
+chai.use(require('chai-json-schema-ajv')
+  .create({
+    verbose: true
+  }));
+
+//TODO add/fix Typescript definition for all these
+Cypress.Commands.add("verifyStatus", { prevSubject: true }, (subject: Cypress.Chainable<Cypress.Response>, status: number) => {
+  expect(subject).to.have.property('status', status);
+  return subject;
+});
+
+
+//TODO it would be good if we could type the output as something we could require for "verifySchema" and "verifyProperties"
+Cypress.Commands.add("itsBody", { prevSubject: true }, (subject: Cypress.Chainable<Cypress.Response>, expectedBody: ResultBody) => {
+  if (!expectedBody) {
+    expect(subject).to.not.have.property('body');
+    return undefined;
+  }
+  else {
+    expect(subject).to.have.property('body');
+    const body = typeof subject.body === 'string' && subject.body.length > 0
+      ? JSON.parse(subject.body)
+      : subject.body;
+    return body;
+  }
+});
+
+
+/** Chains of response.body */
+Cypress.Commands.add("verifySchema", { prevSubject: true }, (subject: Cypress.Chainable<any>, expectedBody: ResultBody) => {
+  if (expectedBody?.schemas) {
+    expectedBody.schemas.forEach((schema) => expect(subject).to.have.jsonSchema(schema));
+  }
+  return subject;
+});
+
+Cypress.Commands.add("verifyProperties", { prevSubject: true }, (subject: Cypress.Chainable<any>, expectedBody: ResultBody) => {
+  if (expectedBody?.properties) {
+    expectedBody.properties.forEach((prop) => {
+      if (prop.exactMatch === false) {
+        expect(subject).to.have.property(prop.name).and.include(prop.value);
+      }
+      else {
+        expect(subject).to.have.property(prop.name).and.eq(prop.value);
+      }
+    });
+  }
+  return subject;
+});

--- a/Gateway/crds-angular.api_test/docker/docker-compose.yml
+++ b/Gateway/crds-angular.api_test/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3'
 services:
   gateway_api_tests:
     build:

--- a/Gateway/crds-angular.api_test/tsconfig.json
+++ b/Gateway/crds-angular.api_test/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "es5",
     "lib": ["es5", "dom"],
     "types": ["cypress", "node"]


### PR DESCRIPTION
- Added coverage for 4 endpoints:
POST /api/v{apiVersion}/request-password-reset
POST /api/requestpasswordreset
POST /api/v{apiVersion}/request-password-reset-mobile
POST /api/requestpasswordreset/mobile
- Created a folder in Vault specifically for this project and added secrets to it (added in all environments)
- Created Cypress commands to handle all the assertions made against responses. These commands can be found in `cypress/support/responseCommands.ts` and are automatically loaded into each test file - no import needed.
- Moved all test user data to `cypress/shared/users.ts` with notes about their requirements. 
- Restructured configs for "defining" test scenarios in a compact manner. New version follows the same basic idea but some property names and function calls have changed. Interfaces and functions still found in `cypress/shared/test_scenario_factory.ts`.
- Added a "preferredResult" property to the TestConfig definition. No assertions are made against them. They can be used to pre-define the expected result after a bug has been fixed, or make a suggestion to improve how an endpoint responds to a scenario.

## TODO
- Add typedefs for custom code
- Improve tsconfig to take advantage of typescript features not being uses
- Convert TSLint to ESLint and improve linting