### PR TITLE
feature/US20275 - API tests for /authenticated endpoint

### DIFF
--- a/Gateway/crds-angular.api_test/cypress.json
+++ b/Gateway/crds-angular.api_test/cypress.json
@@ -1,5 +1,4 @@
 {
-  "projectId": "s1jczs",
   "baseUrl": "https://gatewayint.crossroads.net/gateway",
   "video": false,
   "env": {

--- a/Gateway/crds-angular.api_test/cypress/config/demo_e2e.json
+++ b/Gateway/crds-angular.api_test/cypress/config/demo_e2e.json
@@ -1,0 +1,8 @@
+{
+  "baseUrl": "https://gatewaydemo.crossroads.net/gateway",
+  "video": false,
+  "integrationFolder": "cypress/e2e",
+  "env": {
+    "vaultEnv": "demo"
+  }
+}

--- a/Gateway/crds-angular.api_test/cypress/config/demo_e2e.json
+++ b/Gateway/crds-angular.api_test/cypress/config/demo_e2e.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "ot9w76",
   "baseUrl": "https://gatewaydemo.crossroads.net/gateway",
   "video": false,
   "integrationFolder": "cypress/e2e",

--- a/Gateway/crds-angular.api_test/cypress/config/int_e2e.json
+++ b/Gateway/crds-angular.api_test/cypress/config/int_e2e.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "ot9w76",
   "baseUrl": "https://gatewayint.crossroads.net/gateway",
   "video": false,
   "integrationFolder": "cypress/e2e",

--- a/Gateway/crds-angular.api_test/cypress/config/prod_e2e.json
+++ b/Gateway/crds-angular.api_test/cypress/config/prod_e2e.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "ot9w76",
   "baseUrl": "https://gateway.crossroads.net/gateway",
   "testFiles": "**/*prodspec.ts",
   "video": false,

--- a/Gateway/crds-angular.api_test/cypress/config/prod_e2e.json
+++ b/Gateway/crds-angular.api_test/cypress/config/prod_e2e.json
@@ -1,0 +1,9 @@
+{
+  "baseUrl": "https://gateway.crossroads.net/gateway",
+  "testFiles": "**/*prodspec.ts",
+  "video": false,
+  "integrationFolder": "cypress/e2e",
+  "env": {
+    "vaultEnv": "prod"
+  }
+}

--- a/Gateway/crds-angular.api_test/cypress/config/vault_config.json
+++ b/Gateway/crds-angular.api_test/cypress/config/vault_config.json
@@ -7,6 +7,14 @@
     {
       "secret": "common",
       "keys": ["MP_REST_API_ENDPOINT", "CRDS_MP_COMMON_CLIENT_ID", "CRDS_MP_COMMON_CLIENT_SECRET"]
+    },
+    {
+      "secret": "Crossroads.Service.Auth",
+      "keys": ["OKTA_OAUTH_BASE_URL"]
+    },
+    {
+      "secret": "Crossroads.Automation",
+      "keys": ["OKTA_TOKEN_AUTH"]
     }
   ]
 }

--- a/Gateway/crds-angular.api_test/cypress/e2e/login_and_authenticate_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/e2e/login_and_authenticate_prodspec.ts
@@ -1,0 +1,26 @@
+import { Ben } from "shared/users";
+
+describe('Login and check authentication workflow', () => {
+  it('Logs a user in and verifies token can be authenticated', () => {
+    const username = Ben.email;
+    const password = Ben.password as string;
+    const mpLoginRequest: Partial<Cypress.RequestOptions> = {
+      url: "/api/login",
+      method: "POST",
+      body: { username, password }
+    };
+
+    cy.request(mpLoginRequest)
+      .its('body.userToken')
+      .then((token) => {
+        const authenticatedRequest: Partial<Cypress.RequestOptions> = {
+          url: "/api/authenticated",
+          method: "GET",
+          headers: { Authorization: token }
+        };
+
+        cy.request(authenticatedRequest)
+          .its('status').should('eq', 200)
+      });
+  });
+});

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_oktaauth_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_oktaauth_spec.ts
@@ -34,7 +34,6 @@ const testConfig: TestConfig[] = [
   }
 ];
 
-//Looks like this only supports MP auth
 describe('GET /api/authenticated', () => {
   unzipTests(testConfig)
   .forEach((t: Test) => {

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_oktaauth_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_oktaauth_spec.ts
@@ -1,0 +1,76 @@
+import { getToken as getOktaToken} from "shared/authorization/okta_user_auth";
+import { Test, TestConfig, unzipTests } from "shared/test_scenario_factory";
+import { Ben } from "shared/users";
+import { mpAuthenticatedBasicAuthContract, mpAuthenticatedSchemaProperties } from "./schemas/authenticatedResponse";
+
+/** Test users cannot be authenticated in Okta Prod at this time. */
+
+//Test Data
+const testConfig: TestConfig[] = [
+  {
+    setup: [
+      {
+        description: "Okta Authorization token",
+        setup: function () {
+          return getOktaToken(Ben.email, Ben.password as string)
+            .then((token) => {
+              this.data.header = { Authorization: token }
+            });
+        }
+      }  
+    ],
+    result: {
+      status: 401,
+      body: {
+        schemas: [{ type: "string", maxLength: 0 }]
+      }
+    },
+    preferredResult: {
+      status: 200,
+      body: {
+        schemas: [mpAuthenticatedBasicAuthContract, mpAuthenticatedSchemaProperties]
+      }
+    }
+  }
+];
+
+//Looks like this only supports MP auth
+describe('GET /api/authenticated', () => {
+  unzipTests(testConfig)
+  .forEach((t: Test) => {
+    it(t.title, () => {
+      const authenticatedRequest: Partial<Cypress.RequestOptions> = {
+        url: "/api/authenticated",
+        method: "GET",
+        failOnStatusCode: false
+      };
+
+      t.setup() //Arrange
+        .then(() => cy.request(t.buildRequest(authenticatedRequest))) //Act
+        .verifyStatus(t.result.status) //Assert
+        .itsBody(t.result.body)
+        .verifySchema(t.result.body)
+        .verifyProperties(t.result.body);
+    });
+  });
+});
+
+describe('GET /api/v1.0.0/authenticated', () => {
+  unzipTests(testConfig)
+  .forEach((t: Test) => {
+    it(t.title, () => {
+      const authenticatedRequest: Partial<Cypress.RequestOptions> = {
+        url: "/api/v1.0.0/authenticated",
+        method: "GET",
+        failOnStatusCode: false
+      };
+
+      t.setup() //Arrange
+        .then(() => cy.request(t.buildRequest(authenticatedRequest))) //Act
+        .verifyStatus(t.result.status) //Assert
+        .itsBody(t.result.body)
+        .verifySchema(t.result.body)
+        .verifyProperties(t.result.body);
+    });
+  });
+});

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_prodspec.ts
@@ -1,0 +1,123 @@
+//is get - what is being sent and how?
+// is authorization token - where get? Pretty sure it's the AuthDTO token used in Identity. 
+// It's user authentication - not client authentication
+
+import { getToken as getMPToken} from "shared/authorization/mp_user_auth";
+import { getToken as getOktaToken} from "shared/authorization/okta_user_auth";
+import { Test, TestConfig, unzipTests } from "shared/test_scenario_factory";
+import { Ben } from "shared/users";
+import { mpAuthenticatedBasicAuthContract, mpAuthenticatedSchemaProperties, errorHasOccurredProperties, errorHasOccurredContract } from './schemas/authenticatedResponse';
+
+//TODO would login set cookies? (e2e - okta and mp)
+
+//Test Data
+const testConfig: TestConfig[] = [
+  {
+    setup: [
+      {
+        description: "Valid Request",
+        setup: function () {
+          return getMPToken(Ben.email, Ben.password as string)
+            .then((token) => {
+              this.data.header = { Authorization: token }
+            });
+        }
+      }      
+    ],
+    result: {
+      status: 200,
+      body: {
+        schemas: [mpAuthenticatedBasicAuthContract, mpAuthenticatedSchemaProperties]
+      }
+    }
+  },
+  {
+    setup: [
+      {
+        description: "Expired Authorization token",
+        data: {
+          header: {
+            Authorization: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ijkyc3c1bmhtbjBQS3N0T0k1YS1nVVZlUC1NWSIsImtpZCI6Ijkyc3c1bmhtbjBQS3N0T0k1YS1nVVZlUC1NWSJ9.eyJpc3MiOiJGb3JtcyIsImF1ZCI6IkZvcm1zL3Jlc291cmNlcyIsImV4cCI6MTYwNDQzNDA2MSwibmJmIjoxNjA0NDMyMjYxLCJjbGllbnRfaWQiOiJDUkRTLkNvbW1vbiIsInNjb3BlIjpbImh0dHA6Ly93d3cudGhpbmttaW5pc3RyeS5jb20vZGF0YXBsYXRmb3JtL3Njb3Blcy9hbGwiLCJvZmZsaW5lX2FjY2VzcyIsIm9wZW5pZCJdLCJzdWIiOiJkOTNjNDMxYi02OWQ2LTRiZDYtYTdiZC0zNmRhOWIyOGY3NjIiLCJhdXRoX3RpbWUiOjE2MDQ0MzIyNjEsImlkcCI6Imlkc3J2IiwibmFtZSI6Im1wY3JkcythbGljaWFrZXlzQGdtYWlsLmNvbSIsImFtciI6WyJwYXNzd29yZCJdfQ.knkFeMdE5D6sJRpAyvTMcvqScKl9G0y0o8nXHKtabpai_2Z9FlW9bQrOjrjM6oA8Y3M1Fh7lF2dAVurxG_278fn8lFWThMpDAlPFrB8m3IO4RkBDd6EQduelFHKXuVsae9zAav63KuSdW5L8hTZVWNldEPwxq3TAeG9Mz3Ci61GwKE5AqXqVtopd0dO4w5AS9tr4XDlgj4D1Fk-ypExq4FYYbi_Q6HeuKF_Jn0JT5vivZtl3hW13ZQgTCtCdVjUhkdXc0oNpcCaXFXTAvhpqG2Efz_bZp4ixMBBxpBuNZ3ugB2BjYUx398v1H01Xiq92Ue2sjWe39WLtdqZblP61vQ"
+          }
+        }
+      },
+      {
+        description: "Missing Authorization header"
+      },
+      {
+        description: "Okta Authorization token",
+        setup: function () {
+          return getOktaToken(Ben.email, Ben.password as string)
+            .then((token) => {
+              this.data.header = { Authorization: token }
+            });
+        }
+      }  
+    ],
+    result: {
+      status: 401,
+      body: {
+        schemas: [{ type: "string", maxLength: 0 }]
+      }
+    }
+  },
+  {
+    setup: [
+      {
+        description: "Invalid Authorization token",
+        data: {
+          header: {
+            Authorization: "123"
+          }
+        }
+      }      
+    ],
+    result: {
+      status: 500,
+      body: {
+        schemas: [ errorHasOccurredProperties, errorHasOccurredContract ]
+      }
+    }
+  }
+];
+
+//Looks like this only supports MP auth
+describe('GET /api/authenticated', () => {
+  unzipTests(testConfig)
+  .forEach((t: Test) => {
+    it(t.title, () => {
+      const authenticatedRequest: Partial<Cypress.RequestOptions> = {
+        url: "/api/authenticated",
+        method: "GET",
+        failOnStatusCode: false
+      };
+
+      t.setup() //Arrange
+        .then(() => cy.request(t.buildRequest(authenticatedRequest))) //Act
+        .verifyStatus(t.result.status) //Assert
+        .itsBody(t.result.body)
+        .verifySchema(t.result.body)
+        .verifyProperties(t.result.body);
+    });
+  });
+});
+
+describe('GET /api/v1.0.0/authenticated', () => {
+  unzipTests(testConfig)
+  .forEach((t: Test) => {
+    it(t.title, () => {
+      const authenticatedRequest: Partial<Cypress.RequestOptions> = {
+        url: "/api/v1.0.0/authenticated",
+        method: "GET",
+        failOnStatusCode: false
+      };
+
+      t.setup() //Arrange
+        .then(() => cy.request(t.buildRequest(authenticatedRequest))) //Act
+        .verifyStatus(t.result.status) //Assert
+        .itsBody(t.result.body)
+        .verifySchema(t.result.body)
+        .verifyProperties(t.result.body);
+    });
+  });
+});

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_prodspec.ts
@@ -65,7 +65,6 @@ const testConfig: TestConfig[] = [
   }
 ];
 
-//Looks like this only supports MP auth
 describe('GET /api/authenticated', () => {
   unzipTests(testConfig)
   .forEach((t: Test) => {

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/GET_authenticated_prodspec.ts
@@ -1,14 +1,7 @@
-//is get - what is being sent and how?
-// is authorization token - where get? Pretty sure it's the AuthDTO token used in Identity. 
-// It's user authentication - not client authentication
-
 import { getToken as getMPToken} from "shared/authorization/mp_user_auth";
-import { getToken as getOktaToken} from "shared/authorization/okta_user_auth";
 import { Test, TestConfig, unzipTests } from "shared/test_scenario_factory";
 import { Ben } from "shared/users";
 import { mpAuthenticatedBasicAuthContract, mpAuthenticatedSchemaProperties, errorHasOccurredProperties, errorHasOccurredContract } from './schemas/authenticatedResponse';
-
-//TODO would login set cookies? (e2e - okta and mp)
 
 //Test Data
 const testConfig: TestConfig[] = [
@@ -43,16 +36,7 @@ const testConfig: TestConfig[] = [
       },
       {
         description: "Missing Authorization header"
-      },
-      {
-        description: "Okta Authorization token",
-        setup: function () {
-          return getOktaToken(Ben.email, Ben.password as string)
-            .then((token) => {
-              this.data.header = { Authorization: token }
-            });
-        }
-      }  
+      }
     ],
     result: {
       status: 401,

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_requestpasswordreset_mobile_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_requestpasswordreset_mobile_spec.ts
@@ -1,8 +1,8 @@
 import { getUUID } from "shared/data_generator";
 import { setPasswordResetToken } from "shared/mp_api";
-import { TestCase, TestConfig, unzipTests } from "shared/test_scenario_factory";
 import { Ben } from "shared/users";
 import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
+import { TestConfig, unzipTests, Test } from "shared/test_scenario_factory";
 
 // Data Setup
 const testConfig: TestConfig[] = [
@@ -10,17 +10,21 @@ const testConfig: TestConfig[] = [
     setup: [
       {
         description: "Valid Request",
-        body: { email: Ben.email },
-        dataSetup: function () {
+        data: {
+          body: { email: Ben.email }
+        },
+        setup: function () {
           //Remove any existing token
-          setPasswordResetToken(Ben.email, "")
+          return setPasswordResetToken(Ben.email, "");
         }
       },
       {
         description: "User Has Pending Password Reset Request",
-        body: { email: Ben.email },
-        dataSetup: function () {
-          setPasswordResetToken(Ben.email, getUUID())
+        data: {
+          body: { email: Ben.email },
+        },
+        setup: function () {
+          return setPasswordResetToken(Ben.email, getUUID())
         }
       }
     ],
@@ -28,9 +32,18 @@ const testConfig: TestConfig[] = [
   },
   {
     setup: [
-      { description: "Person Doesn't Exist", body: { email: "this_email_should_not_exist@fake_emails.io" } },
-      { description: "Person has Contact Record but no User Record", body: { email: "mpcrds+LoadTest_98@gmail.com" } },
-      { description: "Invalid Email", body: { email: "{" } },
+      {
+        description: "Person Doesn't Exist",
+        data: { body: { email: "this_email_should_not_exist@fake_emails.io" } }
+      },
+      {
+        description: "Person has Contact Record but no User Record",
+        data: { body: { email: "mpcrds+LoadTest_98@gmail.com" } }
+      },
+      {
+        description: "Invalid Email",
+        data: { body: { email: "{" } }
+      },
     ],
     result: { status: 200 }, //Not technically a bug but misleading to user
     preferredResult: {
@@ -42,14 +55,18 @@ const testConfig: TestConfig[] = [
     }
   },
   {
-    setup: [
-      { description: "Email is Subset of Another Email (bug)", body: { email: "lia@differential.com" } }
-    ],
+    setup:
+    {
+      description: "Email is Subset of Another Email (bug)",
+      data: { body: { email: "lia@differential.com" } }
+    },
     result: { status: 200 },
     preferredResult: { status: 200 } //Should still have valid output, but won't error on server side
   },
   {
-    setup: { description: "Email is Undefined", body: {} },
+    setup: {
+      description: "Email is Undefined", data: { body: {} }
+    },
     result: { status: 200 }, //Not technically a bug but misleading to user
     preferredResult: {
       status: 400,
@@ -77,27 +94,22 @@ const testConfig: TestConfig[] = [
   }
 ];
 
-// Run Tests
 describe('POST /api/requestpasswordreset/mobile', () => {
   unzipTests(testConfig)
-    .forEach((t: TestCase) => {
+    .forEach((t: Test) => {
       it(t.title, () => {
-        if (t.setup.dataSetup) t.setup.dataSetup();
-
-        const mpRequestPasswordReset: Partial<Cypress.RequestOptions> = {
+        const requestPWResetMobile: Partial<Cypress.RequestOptions> = {
           url: "/api/requestpasswordreset/mobile",
           method: "POST",
-          body: t.setup.body,
-          headers: t.setup.header,
           failOnStatusCode: false
         };
 
-        //Act & Assert
-        cy.request(mpRequestPasswordReset)
-          .verifyStatus(t.result.status)
+        t.setup() //Arrange
+          .then(() => cy.request(t.buildRequest(requestPWResetMobile))) //Act
+          .verifyStatus(t.result.status) //Assert
           .itsBody(t.result.body)
-          .verifySchema(t.result.body?.schemas)
-          .verifyProperties(t.result.body?.properties);
+          .verifySchema(t.result.body)
+          .verifyProperties(t.result.body);
       });
     });
 });

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_resetpassword_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_resetpassword_spec.ts
@@ -1,5 +1,5 @@
 import { setPasswordResetToken } from "shared/mp_api";
-import { TestCase, TestConfig, unzipTests } from "shared/test_scenario_factory";
+import { Test, TestConfig, unzipTests } from "shared/test_scenario_factory";
 import { Gatekeeper, KeeperJr } from 'shared/users';
 import { getTestPassword, getUUID } from "shared/data_generator";
 
@@ -9,17 +9,27 @@ const testConfig: TestConfig[] = [
     setup: [
       {
         description: "Valid Request",
-        body: { password: getTestPassword(), token: getUUID() },
-        dataSetup: function () {
-          setPasswordResetToken(Gatekeeper.email, this.body.token)
+        data: {
+          body: {
+            password: getTestPassword(),
+            token: getUUID()
+          }
+        },
+        setup: function () {
+          return setPasswordResetToken(Gatekeeper.email, this.data.body.token)
         }
       },
       {
         //TODO should set password first to guarantee this scenario
         description: "New Password is Current Password",
-        body: { password: KeeperJr.password, token: getUUID() },
-        dataSetup: function () {
-          setPasswordResetToken(KeeperJr.email, this.body.token)
+        data: { 
+          body: {
+            password: KeeperJr.password,
+            token: getUUID()
+          }
+        },
+        setup: function () {
+          return setPasswordResetToken(KeeperJr.email, this.data.body.token)
         }
       }
     ],
@@ -29,30 +39,46 @@ const testConfig: TestConfig[] = [
     setup: [
       {
         description: "Reset Token that Does Not Match any Reset Request",
-        body: { password: getTestPassword(), token: getUUID() },
-        dataSetup: function () {
-          setPasswordResetToken(Gatekeeper.email, "")
-        }
+        data: {
+          body: {
+            password: getTestPassword(),
+            token: getUUID()
+          }
+        },
+        setup: function () {
+          return setPasswordResetToken(Gatekeeper.email, "")
+        },
       },
       {
         description: "Reset Token Value is Substring of Existing Reset Request",
-        body: { password: getTestPassword(), token: getUUID() },
-        dataSetup: function () {
-          setPasswordResetToken(Gatekeeper.email, `${this.body.token}9`)
+        data: {
+         body: {
+            password: getTestPassword(),
+            token: getUUID()
+          }
+        },
+        setup: function () {
+          return setPasswordResetToken(Gatekeeper.email, `${this.data.body.token}9`)
         }
       },
       {
         description: "Request is Missing Reset Token",
-        body: { password: getTestPassword() },
-        dataSetup: function () {
-          setPasswordResetToken(Gatekeeper.email, getUUID())
+        data: {
+          body: {
+            password: getTestPassword()
+          }
+        },
+        setup: function () {
+          return setPasswordResetToken(Gatekeeper.email, getUUID())
         }
       },
       {
         description: "Request is Missing Password",
-        body: { token: getUUID() },
-        dataSetup: function () {
-          setPasswordResetToken(Gatekeeper.email, this.body.token)
+        data: {
+          body: {token: getUUID()}
+        },
+        setup: function () {
+          return setPasswordResetToken(Gatekeeper.email, this.data.body.token)
         }
       }
     ],
@@ -63,48 +89,40 @@ const testConfig: TestConfig[] = [
 // Run Tests
 describe('POST /api/resetpassword', () => {
   unzipTests(testConfig)
-    .forEach((t: TestCase) => {
+    .forEach((t: Test) => {
       it(t.title, () => {
-        if (t.setup.dataSetup) t.setup.dataSetup();
-
         const mpResetPassword: Partial<Cypress.RequestOptions> = {
           url: "/api/resetpassword",
           method: "POST",
-          body: t.setup.body,
-          headers: t.setup.header,
           failOnStatusCode: false
         };
 
-        //Act & Assert
-        cy.request(mpResetPassword)
-          .verifyStatus(t.result.status)
+        t.setup() //Arrange
+          .then(() => cy.request(t.buildRequest(mpResetPassword))) //Act
+          .verifyStatus(t.result.status) //Assert
           .itsBody(t.result.body)
-          .verifySchema(t.result.body?.schemas)
-          .verifyProperties(t.result.body?.properties);
+          .verifySchema(t.result.body)
+          .verifyProperties(t.result.body);
       });
     });
 });
 
 describe('POST /api/v1.0.0/reset-password', () => {
   unzipTests(testConfig)
-    .forEach((t: TestCase) => {
+    .forEach((t: Test) => {
       it(t.title, () => {
-        if (t.setup.dataSetup) t.setup.dataSetup();
-
         const mpResetPassword: Partial<Cypress.RequestOptions> = {
           url: "/api/v1.0.0/reset-password",
           method: "POST",
-          body: t.setup.body,
-          headers: t.setup.header,
           failOnStatusCode: false
         };
 
-        //Act & Assert
-        cy.request(mpResetPassword)
-          .verifyStatus(t.result.status)
+        t.setup() //Arrange
+          .then(() => cy.request(t.buildRequest(mpResetPassword))) //Act
+          .verifyStatus(t.result.status) //Assert
           .itsBody(t.result.body)
-          .verifySchema(t.result.body?.schemas)
-          .verifyProperties(t.result.body?.properties);
+          .verifySchema(t.result.body)
+          .verifyProperties(t.result.body);
       });
     });
 });

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_versioned_request-password-reset-mobile_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_versioned_request-password-reset-mobile_prodspec.ts
@@ -1,4 +1,4 @@
-import { TestCase, TestConfig, unzipTests } from "shared/test_scenario_factory";
+import { Test, TestConfig, unzipTests } from "shared/test_scenario_factory";
 import { Ben } from "shared/users";
 import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
 /**
@@ -10,7 +10,7 @@ import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
 // Data Setup
 const testConfig: TestConfig[] = [
   {
-    setup: { description: "Valid Request", body: { email: Ben.email } },
+    setup: { description: "Valid Request", data: { body: { email: Ben.email } } },
     result: { status: 200 }
   },
   {
@@ -34,24 +34,20 @@ const testConfig: TestConfig[] = [
 // Run Tests
 describe('POST /api/v1.0.0/request-password-reset-mobile', () => {
   unzipTests(testConfig)
-    .forEach((t: TestCase) => {
+    .forEach((t: Test) => {
       it(t.title, () => {
-        const mpRequestPasswordReset: Partial<Cypress.RequestOptions> = {
+        const requestPWResetMobile: Partial<Cypress.RequestOptions> = {
           url: "/api/v1.0.0/request-password-reset-mobile",
           method: "POST",
-          body: t.setup.body,
-          headers: t.setup.header,
           failOnStatusCode: false
         };
 
-        //Act & Assert
-        cy.request(mpRequestPasswordReset)
-          .verifyStatus(t.result.status)
+        t.setup() //Arrange
+          .then(() => cy.request(t.buildRequest(requestPWResetMobile))) //Act
+          .verifyStatus(t.result.status) //Assert
           .itsBody(t.result.body)
-          .verifySchema(t.result.body?.schemas)
-          .verifyProperties(t.result.body?.properties);
+          .verifySchema(t.result.body)
+          .verifyProperties(t.result.body);
       });
     });
 });
-
-

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_versioned_request-password-reset_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/POST_versioned_request-password-reset_prodspec.ts
@@ -1,4 +1,4 @@
-import { TestCase, TestConfig, unzipTests } from "shared/test_scenario_factory";
+import { Test, TestConfig, unzipTests } from "shared/test_scenario_factory";
 import { Ben } from "shared/users";
 import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
 /**
@@ -10,7 +10,7 @@ import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
 // Data Setup
 const testConfig: TestConfig[] = [
   {
-    setup: { description: "Valid Request", body: { email: Ben.email } },
+    setup: { description: "Valid Request", data: { body: { email: Ben.email } } },
     result: { status: 200 }
   },
   {
@@ -34,22 +34,20 @@ const testConfig: TestConfig[] = [
 // Run Tests
 describe('POST /api/v1.0.0/request-password-reset', () => {
   unzipTests(testConfig)
-    .forEach((t: TestCase) => {
+    .forEach((t: Test) => {
       it(t.title, () => {
-        const mpRequestPasswordReset: Partial<Cypress.RequestOptions> = {
+        const requestPasswordReset: Partial<Cypress.RequestOptions> = {
           url: "/api/v1.0.0/request-password-reset",
           method: "POST",
-          body: t.setup.body,
-          headers: t.setup.header,
           failOnStatusCode: false
         };
 
-        //Act & Assert
-        cy.request(mpRequestPasswordReset)
-          .verifyStatus(t.result.status)
+        t.setup() //Arrange
+          .then(() => cy.request(t.buildRequest(requestPasswordReset))) //Act
+          .verifyStatus(t.result.status) //Assert
           .itsBody(t.result.body)
-          .verifySchema(t.result.body?.schemas)
-          .verifyProperties(t.result.body?.properties);
+          .verifySchema(t.result.body)
+          .verifyProperties(t.result.body);
       });
     });
 });

--- a/Gateway/crds-angular.api_test/cypress/integration/LoginController/schemas/authenticatedResponse.ts
+++ b/Gateway/crds-angular.api_test/cypress/integration/LoginController/schemas/authenticatedResponse.ts
@@ -1,0 +1,69 @@
+// This schema verify a property has the correct type if it exists, it does not assert the property must exist
+export const mpAuthenticatedSchemaProperties = {
+  title: "MP authenticated response - property types",
+  type: "object",
+  properties: {
+    userToken: {
+      type: "string"
+    },
+    userTokenExp: {
+      type: [ "string", "null"]
+    },
+    refreshToken: {
+      type: [ "string", "null"]
+    },
+    userId: {
+      type: "number"
+    },
+    username: {
+      type: "string"
+    },
+    userEmail: {
+      type: "string"
+    },
+    roles: {
+      type: "array",
+      items: {
+        title: "MP Role",
+        type: "object",
+        properties: {
+          Id: { type: "number" },
+          Name: { type: "string" }
+        }
+      },
+      minItems: 0
+    },
+    canImpersonate: {
+      type: "boolean"
+    },
+    age: {
+      type: "number"
+    },
+    userPhone: {
+      type: ["string", "null"]
+    }
+  }
+};
+
+// This schema asserts that a property exists, it does not assert it is of the correct type
+export const mpAuthenticatedBasicAuthContract = {
+  title: "MP authenticated response - user info contract",
+  type: "object",
+  required: ["userToken", "userId", "userEmail"],
+};
+
+export const errorHasOccurredProperties = {
+  title: "MP authenticated error request - property types",
+  type: "object",
+  properties: {
+    Message:{
+      type: "string"
+    }
+  }
+};
+
+export const errorHasOccurredContract = {
+  title: "MP authenticated error request - contract",
+  type: "object",
+  required: ["Message"]
+};

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_client_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_client_auth.ts
@@ -25,11 +25,9 @@ function getNewToken(): Cypress.Chainable<string> {
  */
 function getToken(): Cypress.Chainable<string> {
   if(storedToken === undefined){
-    console.debug('fetching new mp token');
     return getNewToken().then(token => storedToken = token)
   }
   
-  console.debug('fetching stored mp token');
   return cy.wrap(storedToken);
 }
 

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_client_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_client_auth.ts
@@ -1,0 +1,47 @@
+// Tokens not stored globally, so will be shared within a test file but not across multiple test files.
+let storedToken: string;
+
+/**
+ * Gets an MP Authorization token for the CRDS.Common client app
+ */
+function getNewToken(): Cypress.Chainable<string> {
+  const tokenRequest: Partial<Cypress.RequestOptions> = {
+    url: `${Cypress.env('MP_REST_API_ENDPOINT')}/oauth/connect/token`,
+    method: "POST",
+    form: true,
+    body: {
+      client_id: Cypress.env('CRDS_MP_COMMON_CLIENT_ID'),
+      client_secret: Cypress.env('CRDS_MP_COMMON_CLIENT_SECRET'),
+      grant_type: 'client_credentials',
+      scope: 'http://www.thinkministry.com/dataplatform/scopes/all'
+    }
+  };
+
+  return cy.request(tokenRequest).its('body.access_token')
+}
+
+/**
+ * Gets an MP Authorization token for the CRDS.Common client app. Will return existing token if one has been fetched already.
+ */
+function getToken(): Cypress.Chainable<string> {
+  if(storedToken === undefined){
+    console.debug('fetching new mp token');
+    return getNewToken().then(token => storedToken = token)
+  }
+  
+  console.debug('fetching stored mp token');
+  return cy.wrap(storedToken);
+}
+
+
+/**
+ * Adds MP Bearer token authorized by CRDS.Common client app to Cypress request 
+ * @param request 
+ */
+export function authorize(request: Partial<Cypress.RequestOptions>): Cypress.Chainable<Partial<Cypress.RequestOptions>>{
+  return getToken()
+  .then(token => {
+    request.auth = {bearer: token};
+    return request;
+  });
+}

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_user_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_user_auth.ts
@@ -1,0 +1,22 @@
+/**
+ * Gets an MP Authorization token for a user
+ * @param email User's email
+ * @param password User's password
+ */
+export function getToken(email: string, password: string): Cypress.Chainable<string> {
+  const tokenRequest: Partial<Cypress.RequestOptions> = {
+    url: `${Cypress.env('MP_REST_API_ENDPOINT')}/oauth/connect/token`,
+    method: "POST",
+    form: true,
+    body: {
+      client_id: Cypress.env('CRDS_MP_COMMON_CLIENT_ID'),
+      client_secret: Cypress.env('CRDS_MP_COMMON_CLIENT_SECRET'),
+      username: email,
+      password,
+      grant_type: 'password',
+      scope: 'http://www.thinkministry.com/dataplatform/scopes/all'
+    }
+  };
+
+  return cy.request(tokenRequest).its('body.access_token');
+}

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/okta_user_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/okta_user_auth.ts
@@ -1,5 +1,8 @@
-///
-
+/**
+ * Gets an Okta Authorization token for a user. Only available in the non-prod Okta environment.
+ * @param email User's email
+ * @param password User's password
+ */
 export function getToken(email: string, password: string): Cypress.Chainable<string> {
   const tokenRequest: Partial<Cypress.RequestOptions> = {
     method: 'POST',

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/okta_user_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/okta_user_auth.ts
@@ -1,0 +1,18 @@
+///
+
+export function getToken(email: string, password: string): Cypress.Chainable<string> {
+  const tokenRequest: Partial<Cypress.RequestOptions> = {
+    method: 'POST',
+    url: `${Cypress.env('OKTA_OAUTH_BASE_URL')}/v1/token`,
+    headers: { authorization: Cypress.env('OKTA_TOKEN_AUTH') },
+    form: true,
+    body: {
+      grant_type: 'password',
+      username: email,
+      password,
+      scope: 'openid'
+    }
+  };
+
+  return cy.request(tokenRequest).its('body.access_token');
+}

--- a/Gateway/crds-angular.api_test/cypress/shared/mp_api.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/mp_api.ts
@@ -1,43 +1,5 @@
 // Access to MP through their API
-
-let mpToken: string;
-
-function getNewToken(): Cypress.Chainable<string> {
-  const tokenRequest: Partial<Cypress.RequestOptions> = {
-    url: `${Cypress.env('MP_REST_API_ENDPOINT')}/oauth/connect/token`,
-    method: "POST",
-    form: true,
-    body: {
-      client_id: Cypress.env('CRDS_MP_COMMON_CLIENT_ID'),
-      client_secret: Cypress.env('CRDS_MP_COMMON_CLIENT_SECRET'),
-      grant_type: 'client_credentials',
-      scope: 'http://www.thinkministry.com/dataplatform/scopes/all'
-    }
-  };
-
-  return cy.request(tokenRequest).its('body.access_token')
-}
-
-//Gets existing or new token. 
-// Tokens not stored globally, so will be shared within a test file but not across multiple test files.
-function getToken(): Cypress.Chainable<string> {
-  if(mpToken === undefined){
-    console.debug('fetching new mp token');
-    return getNewToken().then(token => mpToken = token)
-  }
-  
-  console.debug('fetching stored mp token');
-  return cy.wrap(mpToken);
-}
-
-// Adds MP Bearer token to request
-function authorize(request: Partial<Cypress.RequestOptions>){
-  return getToken()
-  .then(token => {
-    request.auth = {bearer: token};
-    return request;
-  });
-}
+import { authorize } from "./authorization/mp_client_auth";
 
 //The properties returned depend on the filter
 export interface MPUser {
@@ -63,6 +25,7 @@ export function getMPUser(email: string): Cypress.Chainable<MPUser> {
 
 // Returns user after update
 export function setPasswordResetToken(email: string, resetToken: string): Cypress.Chainable<MPUser>{
+  console.debug(`reset token is set to ${resetToken}`);
   return getMPUser(email)
   .then(mpUser => {
     const updateResetTokenRequest: Partial<Cypress.RequestOptions> = {

--- a/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.ts
@@ -1,9 +1,9 @@
 /**
  * Schema to define test scenarios and their response concisely
- * Use the unzipTests function with a TestConfig or TestConfig[] to generate a TestCase[]
+ * Use the unzipTests function with a TestConfig or TestConfig[] to generate a Test[]
  */
 export interface TestConfig {
-  setup: TestSetup | TestSetup[];
+  setup: TestSetup | TestSetup[]
   result: TestResult;
   /**
    * Preferred Output values are not tested, but capture the expected output for a defect scenario, or a suggestion for improvement
@@ -11,60 +11,81 @@ export interface TestConfig {
   preferredResult?: TestResult;
 }
 
-export interface TestCase {
-  title: string;
-  setup: TestSetup;
-  result: TestResult;
-}
-
-export interface TestSetup {
+interface TestSetup {
+  /** Description of the test scenario */
   description: string;
-  body?: any;
-  header?: any;
-  dataSetup?(): void;
+  /** Store any information needed in the request here. 
+   * The properties "header" and "body" will be used directly in the request. */
+  data?: Record<string, any>;
+  /** Seed the database, generate/fetch test data to store in the data property, etc. here. Must return a chainable. */
+  setup?(): Cypress.Chainable<any>;
 }
 
-export interface TestResult {
+interface TestResult {
+  /** HTTP status code expected */
   status: number;
+  /** Content of response body expected */
   body?: ResultBody;
 }
 
 export interface ResultBody {
-  schemas?: object[];
+  schemas?: any[];
   properties?: PropertyCompare[];
 }
 
-export interface PropertyCompare {
+interface PropertyCompare {
   name: string;
   value: string;
   /**
    * If false, compares with 'includes'; defaults to exact match
    */
   exactMatch?: boolean;
- }
+}
 
-function unzip(config: TestConfig): TestCase[]{
-  const testTitle = (setup: TestSetup, result: TestResult) => {
-    return `Given ${setup.description}; Expect status ${result.status}${result.body?.schemas ? ", valid schema":""}${result.body?.properties ? ", correct property values":""}`;
-  };
+/**
+ * Standardized schema for naming, setting up data and creating request to run in a 
+ * standard Test
+ */
+export interface Test {
+  title: string;
+  data: Record<string, any>; //Use this to share data between f'ns
+  setup(): Cypress.Chainable<any>;//TODO changed from setup.setupData
+  buildRequest(request?: Partial<Cypress.RequestOptions>): Partial<Cypress.RequestOptions>;//TODO changed from setup.setupData
+  result: TestResult
+}
 
-  let scenarios: TestCase[];
-  if(Array.isArray(config.setup)){
-    //handle individual
-    scenarios = config.setup.map((setup) => ({ title: testTitle(setup, config.result), setup, result: config.result }));
+function buildTest(setupConfig: TestSetup, resultConfig: TestResult): Test {
+  const title = `Given ${setupConfig.description}; Expect status ${resultConfig.status}${resultConfig.body?.schemas ? ", valid schema":""}${resultConfig.body?.properties ? ", correct property values":""}`;
+  function buildRequest(request?: Partial<Cypress.RequestOptions>): Partial<Cypress.RequestOptions> {
+    const fullRequest = { ...request,
+      headers: this.data.header,
+      body: this.data.body
+    }
+    return fullRequest;
   }
-  else {
-    scenarios = [{ title: testTitle(config.setup, config.result), setup: config.setup, result: config.result }];
-  }
 
+  const test: Test = {
+    title,
+    data: setupConfig.data || {},
+    setup: setupConfig.setup || function() {return cy.wrap({});},
+    buildRequest,
+    result: resultConfig
+  }
+  return test;
+}
+
+function unzipConfig(config: TestConfig): Test[] {
+  const setups = Array.isArray(config.setup) ? config.setup : [config.setup];
+  const scenarios = setups.map(s => buildTest(s, config.result));
   return scenarios;
 }
 
-export function unzipTests(zippedTests: TestConfig | TestConfig[]): TestCase[] {
-  if(Array.isArray(zippedTests)){
-    return zippedTests.map((config) => (unzip(config))).flat();
-  }
-  else {
-    return unzip(zippedTests);
-  }
+/**
+ * Converts test configurations into tests
+ * @param zippedTests Configurations to be converted into runnable Test[]
+ */
+export function unzipTests(zippedTests: TestConfig | TestConfig[]): Test[] {
+  const configs = Array.isArray(zippedTests) ? zippedTests : [zippedTests];
+  const tests = configs.map(c => unzipConfig(c)).flat();
+  return tests;
 }

--- a/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.ts
@@ -48,9 +48,13 @@ interface PropertyCompare {
  */
 export interface Test {
   title: string;
-  data: Record<string, any>; //Use this to share data between f'ns
-  setup(): Cypress.Chainable<any>;//TODO changed from setup.setupData
-  buildRequest(request?: Partial<Cypress.RequestOptions>): Partial<Cypress.RequestOptions>;//TODO changed from setup.setupData
+  /**
+   * Use this to share data between the setup and buildRequest functions.
+   * data.header and data.body will be used to build the request
+   */
+  data: Record<string, any>;
+  setup(): Cypress.Chainable<any>;
+  buildRequest(request?: Partial<Cypress.RequestOptions>): Partial<Cypress.RequestOptions>;
   result: TestResult
 }
 


### PR DESCRIPTION
- Added API tests for /authenticated
- Reworked TestConfig structure and conversion to be more flexible and allow for async retrieval of values (like requesting auth token via api)
- Added user authentication through Okta and MP, and isolated client authentication through MP. Note that Okta authentication cannot currently be done in the Prod environment for test users.
- Added e2e test for login and authenticated workflow
- Created a Cypress dashboard project for e2e tests