### PR TITLE
feature/US20458 - API test for POST /verifycredentials

### DIFF
--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/GET_authenticated_mpauth_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/GET_authenticated_mpauth_prodspec.ts
@@ -1,4 +1,4 @@
-import { getToken as getMPToken} from "shared/authorization/mp_user_auth";
+import { authorize as authorizeWithMP} from "shared/authorization/mp_user_auth";
 import { unzipTests } from "shared/test_scenario_factory";
 import { Ben } from "shared/users";
 import { mpAuthenticatedBasicAuthContract, mpAuthenticatedSchemaProperties, errorHasOccurredProperties, errorHasOccurredContract } from './schemas/authenticatedResponse';
@@ -9,11 +9,9 @@ const testConfig: TestFactory.TestConfig[] = [
     setup: [
       {
         description: "Valid Request",
+        data: {},
         setup: function () {
-          return getMPToken(Ben.email, Ben.password as string)
-            .then((token) => {
-              this.data.header = { Authorization: token }
-            });
+          return authorizeWithMP(Ben.email, Ben.password as string, this.data);
         }
       }      
     ],
@@ -29,13 +27,14 @@ const testConfig: TestFactory.TestConfig[] = [
       {
         description: "Expired Authorization token",
         data: {
-          header: {
+          headers: {
             Authorization: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ijkyc3c1bmhtbjBQS3N0T0k1YS1nVVZlUC1NWSIsImtpZCI6Ijkyc3c1bmhtbjBQS3N0T0k1YS1nVVZlUC1NWSJ9.eyJpc3MiOiJGb3JtcyIsImF1ZCI6IkZvcm1zL3Jlc291cmNlcyIsImV4cCI6MTYwNDQzNDA2MSwibmJmIjoxNjA0NDMyMjYxLCJjbGllbnRfaWQiOiJDUkRTLkNvbW1vbiIsInNjb3BlIjpbImh0dHA6Ly93d3cudGhpbmttaW5pc3RyeS5jb20vZGF0YXBsYXRmb3JtL3Njb3Blcy9hbGwiLCJvZmZsaW5lX2FjY2VzcyIsIm9wZW5pZCJdLCJzdWIiOiJkOTNjNDMxYi02OWQ2LTRiZDYtYTdiZC0zNmRhOWIyOGY3NjIiLCJhdXRoX3RpbWUiOjE2MDQ0MzIyNjEsImlkcCI6Imlkc3J2IiwibmFtZSI6Im1wY3JkcythbGljaWFrZXlzQGdtYWlsLmNvbSIsImFtciI6WyJwYXNzd29yZCJdfQ.knkFeMdE5D6sJRpAyvTMcvqScKl9G0y0o8nXHKtabpai_2Z9FlW9bQrOjrjM6oA8Y3M1Fh7lF2dAVurxG_278fn8lFWThMpDAlPFrB8m3IO4RkBDd6EQduelFHKXuVsae9zAav63KuSdW5L8hTZVWNldEPwxq3TAeG9Mz3Ci61GwKE5AqXqVtopd0dO4w5AS9tr4XDlgj4D1Fk-ypExq4FYYbi_Q6HeuKF_Jn0JT5vivZtl3hW13ZQgTCtCdVjUhkdXc0oNpcCaXFXTAvhpqG2Efz_bZp4ixMBBxpBuNZ3ugB2BjYUx398v1H01Xiq92Ue2sjWe39WLtdqZblP61vQ"
           }
         }
       },
       {
-        description: "Missing Authorization header"
+        description: "Missing Authorization header",
+        data: {}
       }
     ],
     result: {
@@ -50,7 +49,7 @@ const testConfig: TestFactory.TestConfig[] = [
       {
         description: "Invalid Authorization token",
         data: {
-          header: {
+          headers: {
             Authorization: "123"
           }
         }

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/GET_authenticated_oktaauth_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/GET_authenticated_oktaauth_spec.ts
@@ -1,4 +1,4 @@
-import { getToken as getOktaToken } from "shared/authorization/okta_user_auth";
+import { authorize as authorizeWithOkta } from "shared/authorization/okta_user_auth";
 import { unzipTests } from "shared/test_scenario_factory";
 import { Ben } from "shared/users";
 import { mpAuthenticatedBasicAuthContract, mpAuthenticatedSchemaProperties } from "./schemas/authenticatedResponse";
@@ -13,11 +13,9 @@ const testConfig: TestFactory.TestConfig[] = [
     setup: [
       {
         description: "Okta Authorization token",
+        data: {},
         setup: function () {
-          return getOktaToken(Ben.email, Ben.password as string)
-            .then((token) => {
-              this.data.header = { Authorization: token }
-            });
+          return authorizeWithOkta(Ben.email, Ben.password as string, this.data);
         }
       }
     ],

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/GET_verifyresettoken_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/GET_verifyresettoken_spec.ts
@@ -15,7 +15,7 @@ const testConfig:TestFactory.TestConfig[] = [
           token: getUUID()
         },
         setup: function () {
-          return setPasswordResetToken(Gatekeeper.email, this.data?.token)
+          return setPasswordResetToken(Gatekeeper.email, this.data.token)
         }
       }
     ],

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_login_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_login_prodspec.ts
@@ -25,7 +25,6 @@ const testConfig:TestFactory.TestConfig[] = [
       { description: "Missing Username", data: { body: { password: Ben.password } } },
       { description: "User Doesn't Exist", data: { body: { username: "fakeUser@fakemail.wxyz", password: Ben.password } } },
       { description: "Body Undefined", data: { body: undefined } },
-      { description: "Body Null", data: { body: null } },
       { description: "Body Empty String", data: { body: "" } },
     ],
     result: {

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_mobile_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_mobile_prodspec.ts
@@ -14,7 +14,7 @@ const testConfig:TestFactory.TestConfig[] = [
     result: { status: 200 }
   },
   {
-    setup: { description: "Missing Body" },
+    setup: { description: "Missing Body", data:{} },
     result: {
       status: 500,
       body: {

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_mobile_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_mobile_spec.ts
@@ -77,7 +77,7 @@ const testConfig:TestFactory.TestConfig[] = [
     }
   },
   {
-    setup: { description: "Missing Body" },
+    setup: { description: "Missing Body", data: {} },
     result: {
       status: 500,
       body: {

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_prodspec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_prodspec.ts
@@ -15,7 +15,7 @@ const testConfig:TestFactory.TestConfig[] = [
     result: { status: 200 }
   },
   {
-    setup: { description: "Missing Body" },
+    setup: { description: "Missing Body", data: {} },
     result: {
       status: 500,
       body: {

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_spec.ts
@@ -71,7 +71,7 @@ const testConfig:TestFactory.TestConfig[] = [
     }
   },
   {
-    setup: { description: "Missing Body" },
+    setup: { description: "Missing Body", data: {} },
     result: {
       status: 500,
       body: {

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_resetpassword_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_resetpassword_spec.ts
@@ -16,7 +16,7 @@ const testConfig:TestFactory.TestConfig[] = [
           }
         },
         setup: function () {
-          return setPasswordResetToken(Gatekeeper.email, this.data?.body.token)
+          return setPasswordResetToken(Gatekeeper.email, this.data.body?.token)
         }
       },
       {
@@ -29,7 +29,7 @@ const testConfig:TestFactory.TestConfig[] = [
           }
         },
         setup: function () {
-          return setPasswordResetToken(KeeperJr.email, this.data.body.token)
+          return setPasswordResetToken(KeeperJr.email, this.data.body?.token)
         }
       }
     ],
@@ -58,7 +58,7 @@ const testConfig:TestFactory.TestConfig[] = [
           }
         },
         setup: function () {
-          return setPasswordResetToken(Gatekeeper.email, `${this.data.body.token}9`)
+          return setPasswordResetToken(Gatekeeper.email, `${this.data.body?.token}9`)
         }
       },
       {
@@ -78,7 +78,7 @@ const testConfig:TestFactory.TestConfig[] = [
           body: { token: getUUID() }
         },
         setup: function () {
-          return setPasswordResetToken(Gatekeeper.email, this.data.body.token)
+          return setPasswordResetToken(Gatekeeper.email, this.data.body?.token)
         }
       }
     ],

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_verifycredentials_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_verifycredentials_spec.ts
@@ -1,0 +1,140 @@
+import { unzipTests } from "shared/test_scenario_factory";
+import { Ben, Sue } from 'shared/users';
+import { getToken as getMPToken} from "shared/authorization/mp_user_auth";
+import { getToken as getOktaToken } from "shared/authorization/okta_user_auth";
+
+function AddMPAuthHeader(email: string, password: string) {
+  return function() {
+    return getMPToken(email, password) 
+    .then((token) => {
+      this.data.header = { Authorization: token }
+    });
+  }  
+}
+
+function AddOktaAuthHeader(email: string, password: string) {
+  return function () {
+    return getOktaToken(email, password as string)
+      .then((token) => {
+        this.data.header = { Authorization: token }
+      });
+  }
+}
+
+// Data Setup
+const testConfig:TestFactory.TestConfig[] = [
+  {
+    setup: [
+      {
+        description: "Valid Request using MP Auth",
+        data: {
+          body: {
+            username: Ben.email,
+            password: Ben.password
+          }
+        },
+        setup: AddMPAuthHeader(Ben.email, Ben.password as string)
+      },
+      {
+        description: "Valid Request using Okta Auth",
+        data: {
+          body: {
+            username: Ben.email,
+            password: Ben.password
+          }
+        },
+        setup: AddOktaAuthHeader(Ben.email, Ben.password as string)
+      },
+      {
+        description: "Request authorized by a different user",
+        data: {
+          body: {
+            username: Ben.email,
+            password: Ben.password
+          }
+        },
+        setup: AddOktaAuthHeader(Sue.email, Sue.password as string)
+      },
+    ],
+    result: { 
+      status: 200
+     }
+  },
+  {
+    setup: [
+      {
+        description: "Invalid user password",
+        data: {
+          body: {
+            username: Ben.email,
+            password: "NotAPassword"
+          }
+        },
+        setup: AddOktaAuthHeader(Ben.email, Ben.password as string)
+      },
+      {
+        description: "Incorrect email",
+        data: {
+          body: {
+            username: `123${Ben.email}`,
+            password: Ben.password
+          }
+        },
+        setup: AddOktaAuthHeader(Ben.email, Ben.password as string)
+      },
+      {
+        description: "Request missing authorization",
+        data: {
+          body: {
+            username: Ben.email,
+            password: Ben.password
+          }
+        }
+      },
+    ],
+    result: { 
+      status: 401
+     }
+  }
+];
+
+// Run Tests
+describe('POST /api/verifycredentials', () => {
+  unzipTests(testConfig)
+    .forEach((t: TestFactory.Test) => {
+      it(t.title, () => {
+        const mpVerifyCredentials: Partial<Cypress.RequestOptions> = {
+          url: `/api/verifycredentials`,
+          method: "POST",
+          failOnStatusCode: false
+        };
+
+        t.setup() //Arrange
+          .then(() => cy.request(t.buildRequest(mpVerifyCredentials))) //Act
+          .verifyStatus(t.result.status) //Assert
+          .itsBody(t.result.body)
+          .verifySchema(t.result.body)
+          .verifyProperties(t.result.body);
+      });
+    });
+});
+
+describe('POST /api/v1.0.0/verify-credentials', () => {
+  unzipTests(testConfig)
+    .forEach((t: TestFactory.Test) => {
+      it(t.title, () => {
+        const mpVerifyResetToken: Partial<Cypress.RequestOptions> = {
+          url: `/api/v1.0.0/verify-credentials`,
+          method: "POST",
+          failOnStatusCode: false
+        };
+
+        t.setup() //Arrange
+          .then(() => cy.request(t.buildRequest(mpVerifyResetToken))) //Act
+          .verifyStatus(t.result.status) //Assert
+          .itsBody(t.result.body)
+          .verifySchema(t.result.body)
+          .verifyProperties(t.result.body);
+      });
+    });
+});

--- a/Gateway/crds-angular.api_test/cypress/config/vault_config.json
+++ b/Gateway/crds-angular.api_test/cypress/config/vault_config.json
@@ -17,6 +17,7 @@
       "keys": [
         "OKTA_TOKEN_AUTH",
         "BEN_KENOBI_PW",
+        "TEST_USER_PW",
         "TEST_GATEKEEPER_PW",
         "TEST_GATEKEEPERJR_PW",
         "CRDS_MP_TESTAUTOMATION_CLIENT_ID",

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_user_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_user_auth.ts
@@ -20,3 +20,18 @@ export function getToken(email: string, password: string): Cypress.Chainable<str
 
   return cy.request(tokenRequest).its('body.access_token');
 }
+
+/**
+ * Adds MP Authorization token header authorized by the given user to Cypress request 
+ * @param request 
+ */
+export function authorize(email: string, password: string, request: Partial<Cypress.RequestOptions>): Cypress.Chainable<Partial<Cypress.RequestOptions>>{
+  return getToken(email, password)
+  .then(token => {
+    request.headers = {
+      ...request.headers,
+      Authorization: token
+    }
+    return request;
+  });
+}

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/okta_user_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/okta_user_auth.ts
@@ -20,17 +20,17 @@ export function getToken(email: string, password: string): Cypress.Chainable<str
   return cy.request(tokenRequest).its('body.access_token');
 }
 
-
 /**
  * Adds Okta Authorization token header authorized by the given user to Cypress request 
  * @param request 
  */
-// export function authorize(email: string, password: string, request: Partial<Cypress.RequestOptions>): Cypress.Chainable<Partial<Cypress.RequestOptions>>{
-//   return getToken(email, password)
-//   .then(token => {
-//     request.headers
-//     .header = { Authorization: token }
-//     request.auth = {bearer: token};
-//     return request;
-//   });
-// }
+export function authorize(email: string, password: string, request: Partial<Cypress.RequestOptions>): Cypress.Chainable<Partial<Cypress.RequestOptions>>{
+  return getToken(email, password)
+  .then(token => {
+    request.headers = {
+      ...request.headers,
+      Authorization: token
+    }
+    return request;
+  });
+}

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/okta_user_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/okta_user_auth.ts
@@ -19,3 +19,18 @@ export function getToken(email: string, password: string): Cypress.Chainable<str
 
   return cy.request(tokenRequest).its('body.access_token');
 }
+
+
+/**
+ * Adds Okta Authorization token header authorized by the given user to Cypress request 
+ * @param request 
+ */
+// export function authorize(email: string, password: string, request: Partial<Cypress.RequestOptions>): Cypress.Chainable<Partial<Cypress.RequestOptions>>{
+//   return getToken(email, password)
+//   .then(token => {
+//     request.headers
+//     .header = { Authorization: token }
+//     request.auth = {bearer: token};
+//     return request;
+//   });
+// }

--- a/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.d.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.d.ts
@@ -15,12 +15,15 @@ declare namespace TestFactory {
   interface TestSetup {
     /** Description of the test scenario */
     description: string;
-    /** Store any information needed in the request here. The properties "header" and "body" will be used directly in the request. */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data?: Record<string, any>;
+    /** Store any information needed in the request here. The Cypress.RequestOptions "headers" and "body" will be used directly in the request. */
+    data: TestData;
     /** Seed the database, generate/fetch test data to store in the data property, etc. here. Must return a chainable. */
     setup?(): Cypress.Chainable<unknown>;
   }
+
+  /** Data can contain any part of a Cypress.RequestOptions and anything else */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface TestData extends Partial<Cypress.RequestOptions>, Record<string, any>{ }
 
   interface TestResult {
     /** HTTP status code expected */
@@ -48,8 +51,7 @@ declare namespace TestFactory {
      * Use this to share data between the setup and buildRequest functions.
      * data.header and data.body will be used to build the request
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: Record<string, any>;
+    data: TestData;
     setup(): Cypress.Chainable<unknown>;
     buildRequest(request?: Partial<Cypress.RequestOptions>): Partial<Cypress.RequestOptions>;
     result: TestResult

--- a/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/test_scenario_factory.ts
@@ -7,7 +7,7 @@ function buildTest(setupConfig: TestFactory.TestSetup, resultConfig: TestFactory
     setup: setupConfig.setup || function() {return cy.wrap({});},
     buildRequest: function(request?: Partial<Cypress.RequestOptions>): Partial<Cypress.RequestOptions> {
       return { ...request,
-        headers: this.data.header,
+        headers: this.data.headers,
         body: this.data.body
       }
     },

--- a/Gateway/crds-angular.api_test/cypress/shared/users.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/users.ts
@@ -14,6 +14,16 @@ export const Ben: TestUser = {
   password: Cypress.env("BEN_KENOBI_PW")
 };
 
+/**
+ * Sue is a test user with the same MP contact ID in every environment.
+ * It is safe to authenticate with either MP or Okta, and will be safe post-cutover.
+ * DO NOT change her email, password or anything that may prevent her from logging in,
+ *   even temporarily.
+ */
+export const Sue: TestUser = {
+  email: "mpcrds+auto+suesmith@gmail.com",
+  password: Cypress.env("TEST_USER_PW")
+};
 
 /**
  * Gate is a test user in non-prod environments.


### PR DESCRIPTION
- Added new tests for POST /api/verifycredentials
- Standardized and made required the `data` property so it's the same in both the TestConfig and Test objects
- Added a wrapper for MP and Okta user auth that adds the Authentication token to a given request