### PR TITLE
defect/DE8140 - Fix when person has email that is substring of email

### DIFF
--- a/Gateway/MinistryPlatform.Translation/Repositories/ContactRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/ContactRepository.cs
@@ -1,19 +1,18 @@
-﻿using System;
+﻿using Crossroads.Web.Auth.Models;
+using Crossroads.Web.Common.Configuration;
+using Crossroads.Web.Common.MinistryPlatform;
+using Crossroads.Web.Common.Security;
+using log4net;
+using MinistryPlatform.Translation.Extensions;
+using MinistryPlatform.Translation.Models;
+using MinistryPlatform.Translation.Models.MinistryPlatform.Translation.Models;
+using MinistryPlatform.Translation.Repositories.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
-using System.Web.UI.WebControls;
-using log4net;
-using Crossroads.Web.Common.Configuration;
-using Crossroads.Web.Common.MinistryPlatform;
-using Crossroads.Web.Common.Security;
-using MinistryPlatform.Translation.Extensions;
-using MinistryPlatform.Translation.Models;
-using MinistryPlatform.Translation.Models.MinistryPlatform.Translation.Models;
-using MinistryPlatform.Translation.Repositories.Interfaces;
-using Crossroads.Web.Auth.Models;
 
 namespace MinistryPlatform.Translation.Repositories
 {
@@ -189,13 +188,11 @@ namespace MinistryPlatform.Translation.Repositories
             {
                 // Given "email" may be a substring of the Email_Address of the records returned (ex. "tester@gmail.com" and "cool_tester@gmail.com")
                 // Filter again to include only exact email matches
-                var exactEmailMatch = records.FindAll(r => r.ToString("Email_Address").Equals(email));
-                if (exactEmailMatch.Count > 1)
+                records = records.FindAll(r => r.ToString("Email_Address").Equals(email));
+                if (records.Count > 1)
                 {
                     throw new Exception("User email did not return exactly one user record");
                 }
-
-                records = exactEmailMatch;
             }
 
             if (records.Count < 1)

--- a/Gateway/MinistryPlatform.Translation/Repositories/ContactRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/ContactRepository.cs
@@ -187,8 +187,17 @@ namespace MinistryPlatform.Translation.Repositories
             var records = _ministryPlatformService.GetRecordsDict(_configurationWrapper.GetConfigIntValue("Contacts"), ApiLogin(), (email));
             if (records.Count > 1)
             {
-                throw new Exception("User email did not return exactly one user record");
+                // Given "email" may be a substring of the Email_Address of the records returned (ex. "tester@gmail.com" and "cool_tester@gmail.com")
+                // Filter again to include only exact email matches
+                var exactEmailMatch = records.FindAll(r => r.ToString("Email_Address").Equals(email));
+                if (exactEmailMatch.Count > 1)
+                {
+                    throw new Exception("User email did not return exactly one user record");
+                }
+
+                records = exactEmailMatch;
             }
+
             if (records.Count < 1)
             {
                 return 0;

--- a/Gateway/MinistryPlatform.Translation/Repositories/UserRepository.cs
+++ b/Gateway/MinistryPlatform.Translation/Repositories/UserRepository.cs
@@ -1,17 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Text.RegularExpressions;
-using Crossroads.Utilities.Interfaces;
-using Crossroads.Web.Common;
-using Crossroads.Web.Common.Configuration;
+﻿using Crossroads.Web.Common.Configuration;
 using Crossroads.Web.Common.MinistryPlatform;
 using Crossroads.Web.Common.Security;
 using MinistryPlatform.Translation.Extensions;
 using MinistryPlatform.Translation.Models;
 using MinistryPlatform.Translation.Models.DTO;
 using MinistryPlatform.Translation.Repositories.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
 
 namespace MinistryPlatform.Translation.Repositories
 {
@@ -185,6 +182,13 @@ namespace MinistryPlatform.Translation.Repositories
         public int GetUserIdByUsername(string email)
         {
             var records = _ministryPlatformService.GetRecordsDict(Convert.ToInt32(ConfigurationManager.AppSettings["Users"]), ApiLogin(), (email));
+             if (records.Count > 1)
+            {
+                // Given "email" may be a substring of the User_Name of the records returned (ex. "tester@gmail.com" and "cool_tester@gmail.com")
+                // Filter again to include only exact email matches
+                records = records.FindAll(r => r.ToString("User_Name").Equals(email));
+            }
+
             if (records.Count != 1)
             {
                 throw new ApplicationException("User email did not return exactly one user record");

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_mobile_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_mobile_spec.ts
@@ -1,6 +1,6 @@
 import { getUUID } from "shared/data_generator";
 import { setPasswordResetToken } from "shared/mp_api";
-import { Ben } from "shared/users";
+import { Ben, KeeperJr } from "shared/users";
 import { badRequestContract, badRequestProperties } from "./schemas/badRequest";
 import { runTest, unzipScenarios } from "shared/CAT/cypress_api_tests";
 
@@ -39,6 +39,11 @@ const successScenarios: CAT.CompactTestScenario = {
         response: {
           status: 200
         }
+    },
+    {
+      description: "Email is Substring of Another Email",
+      request: { body: { email: KeeperJr.email } },
+      response: { status: 200 },
     },
     {
       description: "Person Doesn't Exist",
@@ -80,15 +85,6 @@ const successScenarios: CAT.CompactTestScenario = {
         status: 404,
         schemas: [badRequestProperties, badRequestContract],
         properties: [{ name: "message", value: "User Not Found" }]
-      }
-    },
-    {
-      description: "Email is Subset of Another Email (bug)",
-      request: { body: { email: "lia@differential.com" } },
-      response: { status: 200 },
-      preferredResponse: { 
-        //Should still have valid output, but won't error on server side
-        status: 200 
       }
     },
     {

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LoginController/POST_requestpasswordreset_spec.ts
@@ -41,6 +41,14 @@ const successScenarios: CAT.CompactTestScenario = {
         }
     },
     {
+      description: "Email is Substring of Another Email",
+      request: { body: { email: KeeperJr.email } },
+      response: { status: 200 },
+      preferredResponse: { 
+        status: 200 
+      }
+    },
+    {
       description: "Person Doesn't Exist",
       request: { 
         body: { 
@@ -80,15 +88,6 @@ const successScenarios: CAT.CompactTestScenario = {
         status: 404,
         schemas: [badRequestProperties, badRequestContract],
         properties: [{ name: "message", value: "User Not Found" }]
-      }
-    },
-    {
-      description: "Email is Subset of Another Email (bug)",
-      request: { body: { email: KeeperJr.email } },
-      response: { status: 200 },
-      preferredResponse: { 
-        //Should still have valid output, but won't error on server side
-        status: 200 
       }
     },
     {

--- a/Gateway/crds-angular.api_test/cypress/api_tests/UserController/POST_user_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/UserController/POST_user_spec.ts
@@ -116,6 +116,45 @@ const successScenarios: CAT.CompactTestScenario = {
       }
     },
     {
+      description: "Email is substring of existing email",
+      request: {
+        body: {
+          firstname: "Substring email",
+          lastname: "Test",
+          email: Placeholders.assignedInSetup,
+          password: Placeholders.assignedInSetup
+        }
+      },
+      setup() {
+        // Register a test user so we have an email to be a substring of
+        const superEmail = getTempTesterEmail();
+        const registerSuperEmail = {
+          url: "/api/user",
+          method: "POST",
+          body: {
+            firstname: "Super",
+            lastname: "Email",
+            email: superEmail,
+            password: getTestPassword()
+          }
+        }
+
+        return cy.request(registerSuperEmail)
+        .then(() => {
+          //TODO optimize this - use createAndSetEmail, then create the super email from the gnerated one
+          const subsetEmail = superEmail.slice(0, superEmail.length-1);
+          (this.request.body as { email: string }).email = subsetEmail;
+          (this.response.properties?.find(r => r.name === "email") as CAT.PropertyCompare).value = subsetEmail;
+
+          createAndSetPassword(this);
+          return this;
+        })
+      },
+      response: {
+        status: 200
+      }
+    },
+    {
       description: "User info missing password",
       request: {
         body: {
@@ -245,71 +284,74 @@ const serverErrorScenarios: CAT.CompactTestScenario = {
 }
 
 //Note that this bug does not exist when registering a user through Okta.
-const bug_emailUniqueButSubsetOfContactEmailScenario: CAT.CompactTestScenario = {
-  sharedRequest,
-  scenarios: [
-  {
-      description: "email is subset of existing email",
-      request: {
-        body: {
-          firstname: "Subset email",
-          lastname: "Test",
-          email: Placeholders.assignedInSetup,
-          password: Placeholders.assignedInSetup
-        }
-      },
-      setup() {
-        // Register a test user so we have an email to subset
-        const supersetEmail = getTempTesterEmail();
-        const registerSuperset = {
-          url: "/api/user",
-          method: "POST",
-          body: {
-            firstname: "Super",
-            lastname: "Email",
-            email: supersetEmail,
-            password: getTestPassword()
-          }
-        }
+// const bug_emailUniqueButSubsetOfContactEmailScenario: CAT.CompactTestScenario = {
+//   sharedRequest,
+//   scenarios: [
+//   {
+//       description: "email is subset of existing email",
+//       request: {
+//         body: {
+//           firstname: "Subset email",
+//           lastname: "Test",
+//           email: Placeholders.assignedInSetup,
+//           password: Placeholders.assignedInSetup
+//         }
+//       },
+//       setup() {
+//         // Register a test user so we have an email to subset
+//         const supersetEmail = getTempTesterEmail();
+//         const registerSuperset = {
+//           url: "/api/user",
+//           method: "POST",
+//           body: {
+//             firstname: "Super",
+//             lastname: "Email",
+//             email: supersetEmail,
+//             password: getTestPassword()
+//           }
+//         }
 
-        return cy.request(registerSuperset)
-        .then(() => {
-          const subsetEmail = supersetEmail.slice(0, supersetEmail.length-1);
-          (this.request.body as { email: string }).email = subsetEmail;
+//         return cy.request(registerSuperset)
+//         .then(() => {
+//           const subsetEmail = supersetEmail.slice(0, supersetEmail.length-1);
+//           (this.request.body as { email: string }).email = subsetEmail;
 
-          createAndSetPassword(this, false);
-          return this;
-        })
-      },
-      response: {
-        //Note that THE USER WAS CREATED! but the step to retrieve their contact ID incorrectly 
-        //  found two users (test uer and the superset user registered in setup) so failed, 
-        //  triggering a 500 response
-        status: 500,
-        schemas: [genericServerErrorContract],
-        properties: [{ name: "Message", value: "An error has occurred." }]
-      },
-      preferredResponse: {
-        status: 200,
-        properties: [
-          {
-            name: "email",
-            value: Placeholders.assignedInSetup
-          },
-          {
-            name: "password",
-            value: Placeholders.assignedInSetup
-          }
-        ]
-      }
-    }
-  ]
-};
+//           createAndSetPassword(this, false);
+//           return this;
+//         })
+//       },
+//       response: {
+//         //Note that THE USER WAS CREATED! but the step to retrieve their contact ID incorrectly 
+//         //  found two users (test uer and the superset user registered in setup) so failed, 
+//         //  triggering a 500 response
+//         status: 500,
+//         schemas: [genericServerErrorContract],
+//         properties: [{ name: "Message", value: "An error has occurred." }]
+//       },
+//       preferredResponse: {
+//         status: 200,
+//         properties: [
+//           {
+//             name: "email",
+//             value: Placeholders.assignedInSetup
+//           },
+//           {
+//             name: "password",
+//             value: Placeholders.assignedInSetup
+//           }
+//         ]
+//       }
+//     }
+//   ]
+// };
 
 //Run Tests
 describe('/User/Post()', () => {
   unzipScenarios(successScenarios).forEach(runTest)
-  unzipScenarios(badRequestScenarios).forEach(runTest)
-  unzipScenarios(serverErrorScenarios).forEach(runTest)
-  unzipScenarios(bug_emailUniqueButSubsetOfContactEmailScenario).forEach(runTest)
+  // unzipScenarios(badRequestScenarios).forEach(runTest)
+  // unzipScenarios(serverErrorScenarios).forEach(runTest)
+  // unzipScenarios(bug_emailUniqueButSubsetOfContactEmailScenario).forEach(runTest)
 });
+
+//TODO need to fix Gateway for GetUserIdByUsername and update those tests
+//TODO search through Gateway for other potential problems with emails

--- a/Gateway/crds-angular.api_test/cypress/api_tests/UserController/POST_user_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/UserController/POST_user_spec.ts
@@ -126,8 +126,12 @@ const successScenarios: CAT.CompactTestScenario = {
         }
       },
       setup() {
-        // Register a test user so we have an email to be a substring of
-        const superEmail = getTempTesterEmail();
+        createAndSetEmail(this);
+        createAndSetPassword(this);
+
+        // Register a test user with a longer email
+        const testEmail = (this.request.body as { email: string }).email;
+        const superEmail = testEmail + "m"; //".comm"
         const registerSuperEmail = {
           url: "/api/user",
           method: "POST",
@@ -139,16 +143,7 @@ const successScenarios: CAT.CompactTestScenario = {
           }
         }
 
-        return cy.request(registerSuperEmail)
-        .then(() => {
-          //TODO optimize this - use createAndSetEmail, then create the super email from the gnerated one
-          const subsetEmail = superEmail.slice(0, superEmail.length-1);
-          (this.request.body as { email: string }).email = subsetEmail;
-          (this.response.properties?.find(r => r.name === "email") as CAT.PropertyCompare).value = subsetEmail;
-
-          createAndSetPassword(this);
-          return this;
-        })
+        return cy.request(registerSuperEmail).then(() => this)
       },
       response: {
         status: 200
@@ -283,75 +278,9 @@ const serverErrorScenarios: CAT.CompactTestScenario = {
   ]
 }
 
-//Note that this bug does not exist when registering a user through Okta.
-// const bug_emailUniqueButSubsetOfContactEmailScenario: CAT.CompactTestScenario = {
-//   sharedRequest,
-//   scenarios: [
-//   {
-//       description: "email is subset of existing email",
-//       request: {
-//         body: {
-//           firstname: "Subset email",
-//           lastname: "Test",
-//           email: Placeholders.assignedInSetup,
-//           password: Placeholders.assignedInSetup
-//         }
-//       },
-//       setup() {
-//         // Register a test user so we have an email to subset
-//         const supersetEmail = getTempTesterEmail();
-//         const registerSuperset = {
-//           url: "/api/user",
-//           method: "POST",
-//           body: {
-//             firstname: "Super",
-//             lastname: "Email",
-//             email: supersetEmail,
-//             password: getTestPassword()
-//           }
-//         }
-
-//         return cy.request(registerSuperset)
-//         .then(() => {
-//           const subsetEmail = supersetEmail.slice(0, supersetEmail.length-1);
-//           (this.request.body as { email: string }).email = subsetEmail;
-
-//           createAndSetPassword(this, false);
-//           return this;
-//         })
-//       },
-//       response: {
-//         //Note that THE USER WAS CREATED! but the step to retrieve their contact ID incorrectly 
-//         //  found two users (test uer and the superset user registered in setup) so failed, 
-//         //  triggering a 500 response
-//         status: 500,
-//         schemas: [genericServerErrorContract],
-//         properties: [{ name: "Message", value: "An error has occurred." }]
-//       },
-//       preferredResponse: {
-//         status: 200,
-//         properties: [
-//           {
-//             name: "email",
-//             value: Placeholders.assignedInSetup
-//           },
-//           {
-//             name: "password",
-//             value: Placeholders.assignedInSetup
-//           }
-//         ]
-//       }
-//     }
-//   ]
-// };
-
 //Run Tests
 describe('/User/Post()', () => {
   unzipScenarios(successScenarios).forEach(runTest)
-  // unzipScenarios(badRequestScenarios).forEach(runTest)
-  // unzipScenarios(serverErrorScenarios).forEach(runTest)
-  // unzipScenarios(bug_emailUniqueButSubsetOfContactEmailScenario).forEach(runTest)
+  unzipScenarios(badRequestScenarios).forEach(runTest)
+  unzipScenarios(serverErrorScenarios).forEach(runTest)
 });
-
-//TODO need to fix Gateway for GetUserIdByUsername and update those tests
-//TODO search through Gateway for other potential problems with emails

--- a/Gateway/crds-angular.api_test/cypress/shared/users.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/users.ts
@@ -47,7 +47,8 @@ export const Gatekeeper: TestUser = {
  */
 export const KeeperJr: TestUser = {
   email: "auto+gatekeeper@testmail.com",
-  password: Cypress.env("TEST_GATEKEEPERJR_PW")
+  password: Cypress.env("TEST_GATEKEEPERJR_PW"),
+  firstName: "Gate"
 };
 
 


### PR DESCRIPTION
- When searching for a user or contact by email, records found will be filtered to exactly match the email given before throwing an error if multiple records are found.
- API tests were updated 