### PR TITLE
Feature/US20476 - Adds API tests for GET /api/profile

### DIFF
--- a/Gateway/crds-angular.api_test/cypress/api_tests/ProfileController/GET_profile_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/ProfileController/GET_profile_spec.ts
@@ -1,0 +1,223 @@
+
+import { addAuthorizationHeader as authorizeWithMP } from "shared/authorization/mp_user_auth";
+import { addAuthorizationHeader as authorizeWithOkta } from "shared/authorization/okta_user_auth";
+import { runTest, unzipScenarios } from "shared/CAT/cypress_api_tests";
+import { Placeholders } from "shared/enums";
+import { getContactRecord, setCanImpersonateValue } from "shared/mp_api";
+import { Gatekeeper, KeeperJr } from "shared/users";
+import { errorResponseContract, errorResponseProperties } from "./schemas/errorResponseSchemas";
+import { getProfileContract, getProfilePropertiesSchema } from "./schemas/getProfileSchema";
+
+// We're going to set impersonation rights before we run any tests
+const Impersonator = Gatekeeper;
+const NotImpersonator = KeeperJr;
+
+function setResponsePropertyValue(response: CAT.TestResponse, propName: string, propValue: string) {
+  (response.properties?.find(r => r.name === propName) as CAT.PropertyCompare).value = propValue;
+}
+
+const sharedRequest = {
+  urls: ['/api/profile'],
+  options: {
+    method: 'GET',
+    failOnStatusCode: false
+  }
+}
+
+const successScenarios: CAT.CompactTestScenario = {
+  sharedRequest,
+  sharedResponse: {
+    schemas: [getProfilePropertiesSchema, getProfileContract],
+    properties: [{ name: "emailAddress", value: Placeholders.assignedInSetup }]
+  },
+  scenarios: [
+    {
+      description: "User authorized with MP",
+      request: {},
+      setup() {
+        setResponsePropertyValue(this.response, "emailAddress", NotImpersonator.email);
+        return authorizeWithMP(NotImpersonator.email, NotImpersonator.password as string, this.request)
+          .then(() => this);
+      },
+      response: {
+        status: 200
+      }
+    },
+    {
+      description: "User authorized with Okta",
+      request: {},
+      setup() {
+        setResponsePropertyValue(this.response, "emailAddress", NotImpersonator.email);
+        return authorizeWithOkta(NotImpersonator.email, NotImpersonator.password as string, this.request)
+          .then(() => this);
+      },
+      response: {
+        status: 200
+      }
+    },
+    {
+      description: "User with impersonation privileges and valid donor id query parameter",
+      request: {
+        qs: {
+          impersonateDonorId: Placeholders.assignedInSetup
+        }
+      },
+      setup() {
+        setResponsePropertyValue(this.response, "emailAddress", Impersonator.email);
+        return getContactRecord(NotImpersonator.email)
+          .then((contact) => {
+            // Set Params to impersonate another user
+            (this.request.qs as { impersonateDonorId: MPModels.NullableNumber }).impersonateDonorId = contact.Donor_Record;
+
+            // Authorize
+            return authorizeWithMP(Impersonator.email, Impersonator.password as string, this.request)
+          })
+          .then(() => this);
+      },
+      response: {
+        status: 200
+      },
+      preferredResponse: {
+        // Sooooo, I'd expect it to actually get the info of the person we're trying to impersonate...
+        status: 200,
+        schemas: [getProfilePropertiesSchema, getProfileContract],
+        properties: [{ name: "emailAddress", value: NotImpersonator.email }]
+      }
+    },
+    {
+      description: "User with impersonation privileges and with empty donor id query parameter",
+      request: {
+        url: '/api/profile',
+        method: 'GET',
+        failOnStatusCode: false,
+        qs: {
+          impersonateDonorId: ""
+        }
+      },
+      setup() {
+        setResponsePropertyValue(this.response, "emailAddress", Impersonator.email);
+        return authorizeWithMP(Impersonator.email, Impersonator.password as string, this.request)
+          .then(() => this);
+      },
+      response: {
+        status: 200
+      }
+    }
+  ]
+}
+
+const forbiddenScenarios: CAT.CompactTestScenario = {
+  sharedRequest,
+  sharedResponse: {
+    schemas: [errorResponseProperties, errorResponseContract],
+    properties: [{ name: "message", value: "User is not authorized to impersonate other users." }]
+  },
+  scenarios: [
+    {
+      description: "User without impersonation privileges",
+      request: {
+        qs: {
+          impersonateDonorId: Placeholders.assignedInSetup
+        }
+      },
+      setup() {
+        return getContactRecord(Impersonator.email)
+          .then((contact) => {
+            // Set Params to impersonate another user
+            (this.request.qs as { impersonateDonorId: MPModels.NullableNumber }).impersonateDonorId = contact.Donor_Record;
+
+            // Authorize
+            return authorizeWithMP(NotImpersonator.email, NotImpersonator.password as string, this.request)
+          })
+          .then(() => this);
+      },
+      response: {
+        status: 403
+      }
+    },
+    {
+      description: "User without impersonation privileges and with invalid donor Id",
+      request: {
+        qs: {
+          impersonateDonorId: 1111111
+        }
+      },
+      setup() {
+        return authorizeWithMP(NotImpersonator.email, NotImpersonator.password as string, this.request)
+          .then(() => this);
+      },
+      response: {
+        status: 403
+      }
+    }
+  ]
+}
+
+const conflictScenarios: CAT.CompactTestScenario = {
+  sharedRequest,
+  scenarios: [
+    {
+      description: "User with impersonation privileges but with invalid donor id",
+      request: {
+        qs: {
+          impersonateDonorId: 1111111
+        }
+      },
+      setup() {
+        return authorizeWithMP(Impersonator.email, Impersonator.password as string, this.request)
+          .then(() => this);
+      },
+      response: {
+        status: 409,
+        schemas: [errorResponseProperties, errorResponseContract],
+        properties: [{ name: "message", value: "Could not locate user '' to impersonate." }]
+      }
+    }
+  ]
+}
+
+const unauthorizedScenarios: CAT.CompactTestScenario = {
+  sharedRequest,
+  scenarios: [
+    {
+      description: "Unauthorized request",
+      request: {},
+      response: {
+        status: 401,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "Unauthorized request with impersonate donor query parameter",
+      request: {
+        qs: {
+          impersonateDonorId: Placeholders.assignedInSetup
+        }
+      },
+      setup() {
+        return getContactRecord(NotImpersonator.email)
+          .then((contact) => {
+            // Set Params to impersonate another user
+            (this.request.qs as { impersonateDonorId: MPModels.NullableNumber }).impersonateDonorId = contact.Donor_Record;
+          })
+          .then(() => this);
+      },
+      response: {
+        status: 401,
+        bodyIsEmpty: true
+      }
+    }
+  ]
+}
+
+describe('/profile/GetProfile()', () => {
+  before(() => {
+    setCanImpersonateValue(Impersonator.email, true);
+    setCanImpersonateValue(NotImpersonator.email, false);
+  });
+
+  unzipScenarios(successScenarios).forEach(runTest);
+  unzipScenarios(forbiddenScenarios).forEach(runTest);
+  unzipScenarios(conflictScenarios).forEach(runTest);
+  unzipScenarios(unauthorizedScenarios).forEach(runTest);
+});

--- a/Gateway/crds-angular.api_test/cypress/api_tests/ProfileController/schemas/errorResponseSchemas.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/ProfileController/schemas/errorResponseSchemas.ts
@@ -1,0 +1,22 @@
+export const errorResponseProperties = {
+  title: "Error response - property types",
+  type: "object",
+  properties: {
+    message:{
+      type: "string"
+    },
+    errors:{
+      type: "array",
+      minItems: 0,
+      items: {
+        type: "string"
+      }
+    }
+  }
+};
+
+export const errorResponseContract = {
+  title: "Error response - contract",
+  type: "object",
+  required: ["message"]
+};

--- a/Gateway/crds-angular.api_test/cypress/api_tests/ProfileController/schemas/getProfileSchema.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/ProfileController/schemas/getProfileSchema.ts
@@ -1,0 +1,155 @@
+// This schema verify a property has the correct type if it exists, it does not assert the property must exist
+export const getProfilePropertiesSchema = {
+  title: "Get Properties - property types",
+  type: "object",
+  properties: {
+    addressId: {
+      type: ["number", "null"]
+    },
+    addressLine1: {
+      type: [ "string", "null" ]
+    },
+    addressLine2: {
+      type: [ "string", "null" ]
+    },
+    age: {
+      type: "number"
+    },
+    passportNumber: {
+      type: [ "string", "null" ]
+    },
+    passportFirstname: {
+      type: [ "string", "null" ]
+    },
+    passportLastname: {
+      type: [ "string", "null" ]
+    },
+    passportMiddlename: {
+      type: [ "string", "null" ]
+    },
+    passportExpiration: {
+      type: [ "string", "null" ]
+    },
+    passportCountry: {
+      type: [ "string", "null" ]
+    },
+    anniversaryDate: {
+      type: [ "string", "null" ]
+    },
+    city: {
+      type: [ "string", "null" ]
+    },
+    congregationId: {
+      type: "number"
+    },
+    contactId: {
+      type: "number"
+    },
+    dateOfBirth: {
+      type: "string"
+    },
+    emailAddress: {
+      type: "string"
+    },
+    employerName: {
+      type: [ "string", "null" ]
+    },
+    firstName: {
+      type: "string"
+    },
+    foreignCountry: {
+      type: [ "string", "null" ]
+    },
+    genderId: {
+      type:[ "number", "null" ]
+    },
+    homePhone: {
+      type: [ "string", "null" ]
+    },
+    householdId: {
+      type: "number"
+    },
+    householdName: {
+      type: "string"
+    },
+    lastName: {
+      type: "string"
+    },
+    maidenName: {
+      type: [ "string", "null" ]
+    },
+    maritalStatusId: {
+      type: [ "number", "null" ]
+    },
+    middleName: {
+      type: [ "string", "null" ]
+    },
+    mobileCarrierId: {
+      type: [ "number", "null" ]
+    },
+    mobilePhone: {
+      type: [ "string", "null" ]
+    },
+    nickName: {
+      type: "string"
+    },
+    newPassword: {
+      type: [ "string", "null" ]
+    },
+    oldEmail: {
+      type: [ "string", "null" ]
+    },
+    oldPassword: {
+      type: [ "string", "null" ]
+    },
+    postalCode: {
+      type: [ "string", "null" ]
+    },
+    county: {
+      type: [ "string", "null" ]
+    },
+    state: {
+      type: [ "string", "null" ]
+    },
+    participantStartDate: {
+      type: "string"
+    },
+    attendanceStartDate: {
+      type: [ "string", "null" ]
+    },
+    householdMembers: {
+      type: "array",
+      items: {
+        title: "Household Member",
+        type: "object",
+        properties: {
+          ContactId: { type: "number" },
+          FirstName: { type: "string" },
+          Nickname: { type: "string" },
+          LastName: { type: "string" },
+          DateOfBirth: { type: "string" },
+          HouseholdPosition: { type: "string" },
+          StatementTypeId: { type: "number" },
+          DonorId: { type: "number" },
+          Age: { type: "number" },
+        }
+      },
+      minItems: 1
+    },
+    attributeTypes: {
+      title: "Attribute Types",
+      type: "object",
+    },
+    singleAttributes: {
+      title: "Single Attributes",
+      type: "object"
+    }
+  }
+};
+
+// This schema asserts that a property exists, it does not assert it is of the correct type
+export const getProfileContract = {
+  title: "Get Profile - contract",
+  type: "object",
+  required: ["contactId", "emailAddress", "firstName", "lastName", "householdId", "householdName", "householdMembers"],
+};

--- a/Gateway/crds-angular.api_test/cypress/shared/mp_api.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/mp_api.ts
@@ -1,15 +1,7 @@
 // Access to MP through their API
 import { addAuthorizationHeader } from "./authorization/mp_client_auth";
 
-//The properties returned depend on the filter
-export interface MPUser {
-  User_Name: string,
-  User_ID: number,
-  Password: string,
-  PasswordResetToken: string
-}
-
-export function getMPUser(email: string): Cypress.Chainable<MPUser> {
+export function getMPUser(email: string): Cypress.Chainable<MPModels.User> {
   const userIdRequest: Partial<Cypress.RequestOptions> = {
     url: `${Cypress.env('MP_REST_API_ENDPOINT')}/tables/dp_Users`,
     method: "GET",
@@ -29,7 +21,6 @@ export function getMPUser(email: string): Cypress.Chainable<MPUser> {
 }
 
 export function setPasswordResetToken(email: string, resetToken: string): Cypress.Chainable<Cypress.Response> {
-  console.debug(`reset token is set to ${resetToken}`);
   return getMPUser(email)
     .then(mpUser => {
       const updateResetTokenRequest: Partial<Cypress.RequestOptions> = {
@@ -40,5 +31,43 @@ export function setPasswordResetToken(email: string, resetToken: string): Cypres
 
       return addAuthorizationHeader(updateResetTokenRequest)
         .then(cy.request);
+    });
+}
+
+export function setCanImpersonateValue(email: string, canImpersonate: boolean): Cypress.Chainable<Cypress.Response> {
+  return getMPUser(email)
+    .then(mpUser => {
+      const updateCanImpersonate: Partial<Cypress.RequestOptions> = {
+        url: `${Cypress.env('MP_REST_API_ENDPOINT')}/tables/dp_Users`,
+        method: "PUT",
+        body: [{ User_ID: mpUser.User_ID, Can_Impersonate: canImpersonate }]
+      };
+
+      return addAuthorizationHeader(updateCanImpersonate)
+        .then(cy.request);
+    })
+}
+
+/**
+ * Returns a Contact whose username (from their User account) matches the given email.
+ * @param email 
+ */
+export function getContactRecord(email: string): Cypress.Chainable<MPModels.Contact> {
+  return getMPUser(email)
+    .then(mpUser => {
+      const contactId = mpUser.Contact_ID;
+      const getContactRecord: Partial<Cypress.RequestOptions> = {
+        url: `${Cypress.env('MP_REST_API_ENDPOINT')}/tables/Contacts/${contactId}`,
+        method: "GET",
+      };
+
+      return addAuthorizationHeader(getContactRecord)
+        .then(cy.request)
+        .its('body')
+        .then(body => {
+          const contactData = body[0];
+          assert(contactData, contactData ? '' : `Contact with email ${email} and contact id ${contactId} could not be found in MP`);
+          return contactData;
+        });
     });
 }

--- a/Gateway/crds-angular.api_test/cypress/shared/mp_models.d.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/mp_models.d.ts
@@ -1,0 +1,17 @@
+declare namespace MPModels {
+  type NullableNumber = number | null; //Database return type
+
+  interface User {
+    User_Name: string,
+    User_ID: number,
+    Password: string,
+    PasswordResetToken: string,
+    Contact_ID: number
+  }
+
+  interface Contact {
+    Contact_ID: number,
+    Email_Address: string,
+    Donor_Record: NullableNumber
+  }
+}

--- a/Gateway/crds-angular.api_test/cypress/shared/users.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/users.ts
@@ -60,3 +60,12 @@ export const Load: TestUser = {
   email: "mpcrds+LoadTest_98@gmail.com",
   password: undefined
 };
+
+/**
+ * Luke is a test user in non-prod environments.
+ * They can only be authenticated through Okta.
+ */
+export const Luke: TestUser = {
+  email: "mpcrds+auto+child1@gmail.com",
+  password: Cypress.env("TEST_USER_PW")
+}

--- a/Gateway/crds-angular.api_test/cypress/support/index.ts
+++ b/Gateway/crds-angular.api_test/cypress/support/index.ts
@@ -15,6 +15,7 @@
 
 // Import custom types automatically into all files
 /// <reference path="../shared/CAT/cypress_api_tests.d.ts" />
+/// <reference path="../shared/mp_models.d.ts" />
 
 // Import custom commands automatically into all files
 import './commands';

--- a/Gateway/crds-angular/Controllers/API/ProfileController.cs
+++ b/Gateway/crds-angular/Controllers/API/ProfileController.cs
@@ -67,7 +67,7 @@ namespace crds_angular.Controllers.API
             {
                 var impersonateUserId = impersonateDonorId == null ? string.Empty : _donorService.GetContactDonorForDonorId(impersonateDonorId.Value).Email;
                 try
-                {
+                {//TODO impersonation literally does nothing - the authorized user information is always returned. Is this intended???
                     var person = (impersonateDonorId != null)
                         ? _impersonationService.WithImpersonation(authDTO, impersonateUserId, () => _personService.GetPerson(authDTO.UserInfo.Mp.ContactId))
                         : _personService.GetPerson(authDTO.UserInfo.Mp.ContactId);
@@ -79,7 +79,7 @@ namespace crds_angular.Controllers.API
                 }
                 catch (UserImpersonationException e)
                 {
-                    return (e.GetRestHttpActionResult());
+                    return (e.GetRestHttpActionResult()); //TODO is this helper needed? can be used elsewhere?
                 }
             });
         }


### PR DESCRIPTION
## Test Changes
- Added API test for GET /api/profile endpoint
- Extracted MP models into their own typedef file

## Code Changes
- Separated the impersonation logic from the non-impersonation logic in the GET /api/profile endpoint to make it a bit easier to follow.
- Added some validation logic in UserImpersonationService.DoImpersonation to prevent looking for a "null" user. This scenario was already handled gracefully deeper in the code, but only after wasting a lot of effort querying MP.