### PR TITLE
feature/US20654 - API tests for GET /lookup/{id}/find?email={email}

### DIFF
--- a/Gateway/crds-angular.api_test/cypress/api_tests/LookupController/GET_lookup_find_spec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LookupController/GET_lookup_find_spec.ts
@@ -1,0 +1,432 @@
+//authorized vs unauthorized
+
+import { addAuthorizationHeader as authorizeWithMP } from "shared/authorization/mp_user_auth";
+import { addAuthorizationHeader as authorizeWithOkta } from "shared/authorization/okta_user_auth";
+import { runTest, unzipScenarios } from "shared/CAT/cypress_api_tests";
+import { getContactRecord } from "shared/mp_api";
+import { Ben } from "shared/users";
+import { exceptionResponseContract, exceptionResponseProperties } from "./schemas/exceptionResponseSchemas";
+
+/** Helper Functions */
+let benContactId: number;
+function getBenContactId(){
+  if(benContactId){
+    return cy.wrap(benContactId);
+  }
+
+  return getContactRecord(Ben.email)
+  .then((contact) => {
+    benContactId = contact.Contact_ID
+    return benContactId;
+  })
+}
+
+//The url requires a person's Contact Id, not their User account id
+function setUrl(contactId: string, request: Partial<Cypress.RequestOptions>){
+  request.url = request.url?.replace('{userId}', contactId);
+}
+
+const sharedRequest = {
+  urls: ['/api/lookup/{userId}/find'], //{userId} must be set to a value
+  options: {
+    method: 'GET',
+    failOnStatusCode: false
+  }
+}
+
+const testScenarios: CAT.CompactTestScenario = {
+  sharedRequest,
+  scenarios: [
+    {
+      description: "Unauthorized request where email is missing and contact Id = 0",
+      request:{},
+      setup(){
+          setUrl('0', this.request);
+          return cy.wrap(this);
+        },
+      response: {
+        status: 404,
+        schemas: [exceptionResponseProperties, exceptionResponseContract],
+        properties: [
+          {
+            name: "Message",
+            satisfies(value){
+              return value.includes("No HTTP resource was found that matches the request URI");
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+
+const successScenario: CAT.CompactTestScenario = {
+  sharedRequest,
+  scenarios: [
+    {
+      description: "Unauthorized request where user does not exist and contact Id = 0",
+      request:{
+        qs: {
+          email: 'usershouldnotexist@testmail.com'
+        }
+      },
+      setup(){
+        setUrl('0', this.request);
+        return cy.wrap(this);
+      },
+      response: {
+        status: 200,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "MP Authorized request where user does not exist and contact Id = 0",
+      request:{
+        qs: {
+          email: 'usershouldnotexist@testmail.com'
+        }
+      },
+      setup(){
+        setUrl('0', this.request);
+        return authorizeWithMP(Ben.email, Ben.password!, this.request).then(() => this)
+      },
+      response: {
+        status: 200,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "Ota Authorized request where user does not exist and contact Id = 0",
+      request:{
+        qs: {
+          email: 'usershouldnotexist@testmail.com'
+        }
+      },
+      setup(){
+        setUrl('0', this.request);
+        return authorizeWithOkta(Ben.email, Ben.password!, this.request).then(() => this)
+      },
+      response: {
+        status: 200,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "MP Authorized request where user exists and contact Id matches their account",
+      request:{
+        qs: {
+          email: Ben.email
+        }
+      },
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return authorizeWithMP(Ben.email, Ben.password!, this.request)
+        })
+        .then(() =>  this);
+      },
+      response: {
+        status: 200,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "Okta Authorized request where user exists and contact Id matches their account",
+      request:{
+        qs: {
+          email: Ben.email
+        }
+      },
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return authorizeWithOkta(Ben.email, Ben.password!, this.request)
+        })
+        .then(() =>  this);
+      },
+      response: {
+        status: 200,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "MP Authorized request where user doesn't exist but contact Id matches a real user",
+      request:{
+        qs: {
+          email: 'usershouldnotexist@testmail.com'
+        }
+      },
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return authorizeWithMP(Ben.email, Ben.password!, this.request)
+        })
+        .then(() => this);
+      },
+      response: {
+        status: 200,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "Okta Authorized request where user doesn't exist but contact Id matches a real user",
+      request:{
+        qs: {
+          email: 'usershouldnotexist@testmail.com'
+        }
+      },
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return authorizeWithOkta(Ben.email, Ben.password!, this.request)
+        })
+        .then(() => this);
+      },
+      response: {
+        status: 200,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "Unauthorized request where user doesn't exist but contact Id matches a real user",
+      request:{
+        qs: {
+          email: 'usershouldnotexist@testmail.com'
+        }
+      },
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return this;
+        })
+      },
+      response: {
+        status: 200,
+        bodyIsEmpty: true
+      }
+    }
+  ]
+}
+
+const badRequestScenario: CAT.CompactTestScenario = {
+  sharedRequest,
+  scenarios: [
+    {
+      description: "Unauthorized request where user exists and contact Id = 0",
+      request:{
+        qs: {
+          email: Ben.email
+        }
+      },
+      setup(){
+        setUrl('0', this.request);
+        return cy.wrap(this);
+      },
+      response: {
+        status: 400,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "MP Authorized request where user exists and contact Id = 0",
+      request:{
+        qs: {
+          email: Ben.email
+        }
+      },
+      setup(){
+        setUrl('0', this.request);
+        return authorizeWithMP(Ben.email, Ben.password!, this.request).then(() => this)
+      },
+      response: {
+        status: 400,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "Okta Authorized request where user exists and contact Id = 0",
+      request:{
+        qs: {
+          email: Ben.email
+        }
+      },
+      setup(){
+        setUrl('0', this.request);
+        return authorizeWithOkta(Ben.email, Ben.password!, this.request).then(() => this)
+      },
+      response: {
+        status: 400,
+        bodyIsEmpty: true
+      }
+    },
+    {
+      description: "Unauthorized request where user exists and contact Id matches their account",
+      request:{
+        qs: {
+          email: Ben.email
+        }
+      },
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return this;
+        })
+      },
+      response: {
+        status: 400,
+        bodyIsEmpty: true
+      }
+    }
+  ]
+}
+
+const notFoundScenario: CAT.CompactTestScenario = {
+  sharedRequest,
+  scenarios: [
+    {
+      description: "Unauthorized request where email is missing but contact Id matches a real user",
+      request:{},
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return this;
+        })
+      },
+      response: {
+        status: 404,
+        schemas: [exceptionResponseProperties, exceptionResponseContract],
+        properties: [
+          {
+            name: "Message",
+            satisfies(value){
+              return value.includes("No HTTP resource was found that matches the request URI");
+            }
+          }
+        ]
+      }
+    },
+    {
+      description: "MP Authorized request where email is missing but contact Id matches a real user",
+      request:{},
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return authorizeWithMP(Ben.email, Ben.password!, this.request)
+        })
+        .then(() => this);
+      },
+      response: {
+        status: 404,
+        schemas: [exceptionResponseProperties, exceptionResponseContract],
+        properties: [
+          {
+            name: "Message",
+            satisfies(value){
+              return value.includes("No HTTP resource was found that matches the request URI");
+            }
+          }
+        ]
+      }
+    },
+    {
+      description: "Okta Authorized request where email is missing but contact Id matches a real user",
+      request:{},
+      setup(){
+        return getBenContactId()
+        .then((contactId) => {
+          setUrl(`${contactId}`, this.request);
+          return authorizeWithOkta(Ben.email, Ben.password!, this.request)
+        })
+        .then(() => this);
+      },
+      response: {
+        status: 404,
+        schemas: [exceptionResponseProperties, exceptionResponseContract],
+        properties: [
+          {
+            name: "Message",
+            satisfies(value){
+              return value.includes("No HTTP resource was found that matches the request URI");
+            }
+          }
+        ]
+      }
+    },
+    {
+      description: "Unauthorized request where email is missing and contact Id = 0",
+      request: {},
+      setup() {
+        setUrl('0', this.request);
+        return cy.wrap(this);
+      },
+      response: {
+        status: 404,
+        schemas: [exceptionResponseProperties, exceptionResponseContract],
+        properties: [
+          {
+            name: "Message",
+            satisfies(value){
+              return value.includes("No HTTP resource was found that matches the request URI");
+            }
+          }
+        ]
+      }
+    },
+    {
+      description: "MP Authorized request where email is missing and contact Id = 0",
+      request: {},
+      setup() {
+        setUrl('0', this.request);
+        return authorizeWithMP(Ben.email, Ben.password!, this.request)
+          .then(() => this);
+      },
+      response: {
+        status: 404,
+        schemas: [exceptionResponseProperties, exceptionResponseContract],
+        properties: [
+          {
+            name: "Message",
+            satisfies(value){
+              return value.includes("No HTTP resource was found that matches the request URI");
+            }
+          }
+        ]
+      }
+    },
+    {
+      description: "Okta Authorized request where email is missing and contact Id = 0",
+      request:{},
+      setup() {
+        setUrl('0', this.request);
+        return authorizeWithOkta(Ben.email, Ben.password!, this.request)
+          .then(() => this);
+      },
+      response: {
+        status: 404,
+        schemas: [exceptionResponseProperties, exceptionResponseContract],
+        properties: [
+          {
+            name: "Message",
+            satisfies(value){
+              return value.includes("No HTTP resource was found that matches the request URI");
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+
+describe('/Lookup/EmailExists()', () => {
+  unzipScenarios(successScenario).forEach(runTest);
+  unzipScenarios(badRequestScenario).forEach(runTest);
+  unzipScenarios(notFoundScenario).forEach(runTest);
+})

--- a/Gateway/crds-angular.api_test/cypress/api_tests/LookupController/schemas/exceptionResponseSchemas.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/LookupController/schemas/exceptionResponseSchemas.ts
@@ -1,0 +1,24 @@
+export const exceptionResponseProperties = {
+  title: "Exception response - property types",
+  type: "object",
+  properties: {
+    ExceptionMessage:{
+      type: "string"
+    },
+    ExceptionType:{
+      type: "string",
+    },
+    Message: {
+      type: "string"
+    },
+    StackTrace: {
+      type: "string"
+    }
+  }
+};
+
+export const exceptionResponseContract = {
+  title: "Exception response - contract",
+  type: "object",
+  required: ["Message"]
+};

--- a/Gateway/crds-angular.api_test/cypress/api_tests/ProfileController/POST_profile_nodemospec.ts
+++ b/Gateway/crds-angular.api_test/cypress/api_tests/ProfileController/POST_profile_nodemospec.ts
@@ -7,6 +7,8 @@ import { KeeperJr, SkywalkerFamily } from "shared/users";
 import { errorResponseContract, errorResponseProperties } from "./schemas/errorResponseSchemas";
 import { exceptionResponseContract, exceptionResponseProperties } from "./schemas/exceptionResponseSchemas";
 
+//TODO The Skywalker family is not setup in demo so these tests cannot run. How can we make these compatible?
+
 /**
  * WARNING! Do NOT post to the '/api/profile' endpoint and only give a valid contactId and householdId - all other properties
  * that this endpoint can set will be REMOVED from their Contact record, including their email.

--- a/Gateway/crds-angular.api_test/cypress/config/api/demo.json
+++ b/Gateway/crds-angular.api_test/cypress/config/api/demo.json
@@ -2,6 +2,7 @@
   "projectId": "s1jczs",
   "baseUrl": "https://gatewaydemo.crossroads.net/gateway",
   "integrationFolder": "cypress/api_tests",
+  "ignoreTestFiles": "**/*nodemo*.ts",
   "responseTimeout": 60000,
   "env": {
     "vaultEnv": "demo"

--- a/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_client_auth.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/authorization/mp_client_auth.ts
@@ -2,7 +2,7 @@
 let storedToken: string;
 
 /**
- * Gets an MP Authorization token for the CRDS.Common client app
+ * Gets an MP Authorization token for the CRDS.TestAutomation client app
  */
 function getNewToken(): Cypress.Chainable<string> {
   const tokenRequest: Partial<Cypress.RequestOptions> = {
@@ -21,7 +21,7 @@ function getNewToken(): Cypress.Chainable<string> {
 }
 
 /**
- * Gets an MP Authorization token for the CRDS.Common client app. Will return existing token if one has been fetched already.
+ * Gets an MP Authorization token for the CRDS.TestAutomation client app. Will return existing token if one has been fetched already.
  */
 function getToken(): Cypress.Chainable<string> {
   if(storedToken === undefined){
@@ -33,7 +33,7 @@ function getToken(): Cypress.Chainable<string> {
 
 
 /**
- * Adds MP Bearer token authorized by CRDS.Common client app to Cypress request 
+ * Adds MP Bearer token authorized by CRDS.TestAutomation client app to Cypress request 
  * @param request 
  */
 export function addAuthorizationHeader(request: Partial<Cypress.RequestOptions>): Cypress.Chainable<Partial<Cypress.RequestOptions>>{

--- a/Gateway/crds-angular.api_test/cypress/shared/mp_models.d.ts
+++ b/Gateway/crds-angular.api_test/cypress/shared/mp_models.d.ts
@@ -13,6 +13,7 @@ declare namespace MPModels {
     Contact_ID: number,
     Email_Address: string,
     Donor_Record: NullableNumber,
-    Household_ID: number
+    Household_ID: number,
+    User_Account: NullableNumber
   }
 }

--- a/Gateway/crds-angular/Controllers/API/LookupController.cs
+++ b/Gateway/crds-angular/Controllers/API/LookupController.cs
@@ -1,39 +1,29 @@
-using System;
-using System.Collections.Generic;
-using System.Web.Helpers;
-using System.Web.Http;
-using System.Web.Http.Controllers;
-using System.Web.Http.Description;
-using System.Web.Http.Results;
-using crds_angular.Models.Json;
 using crds_angular.Security;
 using crds_angular.Services.Interfaces;
-using MinistryPlatform.Translation.Repositories;
 using Crossroads.ApiVersioning;
-using Crossroads.Web.Common.Configuration;
 using Crossroads.Web.Common.Security;
+using MinistryPlatform.Translation.Repositories;
 using MinistryPlatform.Translation.Repositories.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Web.Http;
+using System.Web.Http.Description;
 
 namespace crds_angular.Controllers.API
 {
     public class LookupController : ImpersonateAuthBaseController
     {
-        private readonly IConfigurationWrapper _configurationWrapper;
         private readonly LookupRepository _lookupRepository;
-        private readonly IAuthenticationRepository _authenticationRepository;
         private readonly IUserRepository _userService;
 
-        public LookupController(IAuthTokenExpiryService authTokenExpiryService, 
-                                IConfigurationWrapper configurationWrapper, 
-                                LookupRepository lookupRepository, 
-                                IUserImpersonationService userImpersonationService, 
-                                IAuthenticationRepository authenticationRepository, 
-                                IUserRepository userService) 
+        public LookupController(IAuthTokenExpiryService authTokenExpiryService,
+            LookupRepository lookupRepository,
+            IUserImpersonationService userImpersonationService,
+            IAuthenticationRepository authenticationRepository,
+            IUserRepository userService)
             : base(authTokenExpiryService, userImpersonationService, authenticationRepository)
         {
-            _configurationWrapper = configurationWrapper;
             _lookupRepository = lookupRepository;
-            _authenticationRepository = authenticationRepository;
             _userService = userService;
         }
 
@@ -211,6 +201,12 @@ namespace crds_angular.Controllers.API
             });
         }
 
+        /// <summary>
+        /// Checks that a given email does not exist OR (when authorized) that contact record with email address has given contact id
+        /// </summary>
+        /// <param name="contactId"></param>
+        /// <param name="email"></param>
+        /// <returns></returns>
         [ResponseType(typeof(Dictionary<string, object>))]
         [VersionedRoute(template: "lookup/{contactId}/find", minimumVersion: "1.0.0")]
         [Route("lookup/{contactId}/find")]
@@ -234,17 +230,6 @@ namespace crds_angular.Controllers.API
                     return Ok();
                 return BadRequest();
             }, BadRequest);
-        }
-
-        protected static dynamic DecodeJson(string json)
-        {
-            var obj = System.Web.Helpers.Json.Decode(json);
-            if (obj.GetType() != typeof(DynamicJsonArray))
-            {
-                return null;
-            }
-            dynamic[] array = obj;
-            return array;
         }
     }
 }


### PR DESCRIPTION
## Test Changes
- Added API tests for LookupController's GET /lookup/{id}/find?email={email} endpoint
- Added filter to skip tests that can't be run in demo. This is a temporary workaround to skip POST /profile tests since data isn't correctly set up. These tests will still be run in Int.


## Code Changes
- Simplified logic in LookupController.EmailExists and removed code that wasn't cleaned up after an old refactor
- Modified how the endpoint Route is defined to improve clarity and for Swagger accuracy. Swagger now correctly reports that email is a query parameter (previously it was inline) and the misleading `userId` variable was renamed to `contactId`.
- Removed dead code and unneeded constructor parameters from the LookupController class.